### PR TITLE
Fix tray exit handler and adjust host lifecycle

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using Serilog;
 using Serilog.Events;
 using System;
+using System.Windows.Forms;
 
 namespace CalendarSync
 {
@@ -14,9 +15,11 @@ namespace CalendarSync
 		{
 			using var host = CreateHostBuilder(args).Build();
 			var tray = host.Services.GetRequiredService<TrayIconManager>();
-			host.Run();
+			host.StartAsync().GetAwaiter().GetResult();
+			Application.Run();
+			host.StopAsync().GetAwaiter().GetResult();
 			tray.Dispose();
-		}
+               }
 
 		public static IHostBuilder CreateHostBuilder(string[] args) =>
 			Host.CreateDefaultBuilder(args)				

--- a/TrayIconManager.cs
+++ b/TrayIconManager.cs
@@ -20,7 +20,7 @@ public sealed class TrayIconManager : IDisposable
 
 		_menu = new ContextMenuStrip();
 		var exitItem = new ToolStripMenuItem("Exit");
-		exitItem.Click += (_, _) => Environment.Exit(0);
+               exitItem.Click += (_, _) => Application.Exit();
 		_menu.Items.Add(exitItem);
 
 		_notifyIcon = new NotifyIcon


### PR DESCRIPTION
## Summary
- update program startup/shutdown sequence
- dispose tray icon after stopping the host
- make tray exit menu close the application

## Testing
- `dotnet build CalendarSync.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c32aec970832bb55001bcd2c427b8