### PR TITLE
Add exit event for tray icon

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -15,11 +15,17 @@ namespace CalendarSync
 		{
 			using var host = CreateHostBuilder(args).Build();
 			var tray = host.Services.GetRequiredService<TrayIconManager>();
+			
+			tray.ExitClicked += async (_, _) =>
+			{
+			await host.StopAsync();
+			tray.Dispose();
+			Application.Exit();
+			};
+			
 			host.StartAsync().GetAwaiter().GetResult();
 			Application.Run();
-			host.StopAsync().GetAwaiter().GetResult();
-			tray.Dispose();
-               }
+		}
 
 		public static IHostBuilder CreateHostBuilder(string[] args) =>
 			Host.CreateDefaultBuilder(args)				

--- a/TrayIconManager.cs
+++ b/TrayIconManager.cs
@@ -12,6 +12,8 @@ public sealed class TrayIconManager : IDisposable
 	private readonly Icon _deleteIcon;
 	private readonly ContextMenuStrip _menu;
 
+	public event EventHandler? ExitClicked;
+
 	public TrayIconManager()
 	{
 		_idleIcon = new Icon("icon_idle.ico");
@@ -20,7 +22,7 @@ public sealed class TrayIconManager : IDisposable
 
 		_menu = new ContextMenuStrip();
 		var exitItem = new ToolStripMenuItem("Exit");
-               exitItem.Click += (_, _) => Application.Exit();
+		exitItem.Click += (_, _) => ExitClicked?.Invoke(this, EventArgs.Empty);
 		_menu.Items.Add(exitItem);
 
 		_notifyIcon = new NotifyIcon


### PR DESCRIPTION
## Summary
- raise `ExitClicked` from `TrayIconManager`
- handle `ExitClicked` in `Program` and stop the host before exiting

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c36e0b15c832b9041cf93451354d1