### PR TITLE
Enhance event log setup and naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+packages-microsoft-prod.deb
+*.log
+bin/
+obj/

--- a/Program.cs
+++ b/Program.cs
@@ -11,54 +11,40 @@ namespace CalendarSync;
 
 public class Program
 {
-	[STAThread]
-	public static void Main(string[] args)
-	{
+        [STAThread]
+        public static void Main(string[] args)
+        {
+                EventRecorder.Initialize();
+                SubscribeToGlobalExceptions();
+                EventRecorder.WriteEntry("Application startup", EventLogEntryType.Information);
 
-		string source = "CalendarSync";
-		string logName = "Application";
-
-		if (!EventLog.SourceExists(source))
-		{			
-			EventLog.CreateEventSource(source, logName);
-			Process.Start(new ProcessStartInfo
-			{
-				FileName = Assembly.GetExecutingAssembly().Location,
-				UseShellExecute = true,
-				Verb = "runas"
-			});
-			return;
-		}
-
-		using EventLog eventLog = new EventLog(logName)
-		{
-			Source = source
-		};
-
-		using var host = CreateHostBuilder(args).Build();
-		var tray = host.Services.GetRequiredService<TrayIconManager>();
+                using var host = CreateHostBuilder(args).Build();
+                var tray = host.Services.GetRequiredService<TrayIconManager>();
 		
-		tray.ExitClicked += async (_, _) =>
-		{
-		await host.StopAsync();
-		tray.Dispose();
-		Application.Exit();
-		};
+                tray.ExitClicked += async (_, _) =>
+                {
+                        EventRecorder.WriteEntry("Shutdown requested", EventLogEntryType.Information);
+                        await host.StopAsync();
+                        tray.Dispose();
+                        Application.Exit();
+                };
 		
-		host.StartAsync().GetAwaiter().GetResult();
-		Application.Run();
-	}
+                host.StartAsync().GetAwaiter().GetResult();
+                Application.Run();
+                EventRecorder.WriteEntry("Application shutdown", EventLogEntryType.Information);
+        }
 
-	public static IHostBuilder CreateHostBuilder(string[] args) =>
-		Host.CreateDefaultBuilder(args)				
-			.ConfigureServices((hostContext, services) =>
-			{
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+                Host.CreateDefaultBuilder(args)
+                        .ConfigureServices((hostContext, services) =>
+                        {
 				
-				var configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
-				if (!File.Exists(configPath))
-				{
-					throw new FileNotFoundException("config.json not found in the executable directory.");
-				}
+                                var configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
+                                if (!File.Exists(configPath))
+                                {
+                                        EventRecorder.WriteEntry("config.json not found", EventLogEntryType.Error);
+                                        throw new FileNotFoundException("config.json not found in the executable directory.");
+                                }
 				var configJson = File.ReadAllText(configPath);
 				var config = JsonConvert.DeserializeObject<SyncConfig>(configJson);
 
@@ -86,7 +72,30 @@ public class Program
 						)
 					.CreateLogger();
 
-				services.AddLogging(builder => builder.AddSerilog(logger, dispose: true));
-				EventLog.WriteEntry("Main", "Read Config & Started Logging", EventLogEntryType.Information);
-			});
+                                services.AddLogging(builder => builder.AddSerilog(logger, dispose: true));
+                                EventRecorder.WriteEntry("Configuration loaded", EventLogEntryType.Information);
+                        });
+
+        private static void SubscribeToGlobalExceptions()
+        {
+                AppDomain.CurrentDomain.UnhandledException += (_, e) => HandleGlobalException(e.ExceptionObject as Exception);
+                TaskScheduler.UnobservedTaskException += (_, e) =>
+                {
+                        HandleGlobalException(e.Exception);
+                        e.SetObserved();
+                };
+                Application.ThreadException += (_, e) => HandleGlobalException(e.Exception);
+        }
+
+        private static void HandleGlobalException(Exception? ex)
+        {
+                if (ex == null)
+                        return;
+                try
+                {
+                        Log.Fatal(ex, "Unhandled exception");
+                }
+                catch { }
+                EventRecorder.WriteEntry(ex.ToString(), EventLogEntryType.Error);
+        }
 }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Logs are written to:
 ```
 C:\CalendarSync\sync.log
 ```
+High level events are also written to the Windows Event Log under the
+"Application" log. Run the program once as administrator to register the
+"CalendarSync" event source.
 
 ## Security
 

--- a/src/EventRecorder.cs
+++ b/src/EventRecorder.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace CalendarSync.src;
+
+public static class EventRecorder
+{
+    public const string Source = "CalendarSync";
+    private const string LogName = "Application";
+    private static bool _enabled;
+
+    public static void Initialize()
+    {
+        try
+        {
+            if (!EventLog.SourceExists(Source))
+                EventLog.CreateEventSource(Source, LogName);
+            _enabled = true;
+        }
+        catch (Exception ex)
+        {
+            _enabled = false;
+            Console.WriteLine($"Event log source setup failed: {ex.Message}. Run once as administrator to register.");
+        }
+    }
+
+    public static void WriteEntry(string message, EventLogEntryType type)
+    {
+        if (!_enabled)
+            return;
+        try
+        {
+            EventLog.WriteEntry(Source, message, type);
+        }
+        catch (Exception ex)
+        {
+            _enabled = false;
+            Console.WriteLine($"Event log write failed: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rename `EventLogger` helper to `EventRecorder`
- warn when event source creation fails
- update usages to new helper
- document event log usage in README

## Testing
- `dotnet build CalendarSync.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510c443cd4832b915d3dc4eabbdbf8