### PR TITLE
Disable alarms for all-day events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As a COM-Interop application it is optimized to run silently via a Scheduled Tas
 ## Features
 
 - One-Way syncs events from **local Outlook calendar** to **Apple iCloud calendar**
-- Adds a **10-minute** and **3-minute alarm notification** for every synced event
+- Adds a **10-minute** and **3-minute alarm notification** for timed events (no reminders on all-day or multi-day entries)
 - Runs silently and logs to `sync.log`
 - Designed for **restricted corporate environments** — no UI required
 - Tray icon with status tooltip

--- a/src/CalendarSyncService.cs
+++ b/src/CalendarSyncService.cs
@@ -491,8 +491,10 @@ public class CalendarSyncService : BackgroundService
 
                 // Convert 24h+ spans starting at midnight to all-day events
                 var span = appt.End - appt.Start;
-                if (appt.Start.TimeOfDay == TimeSpan.Zero && span.TotalHours >= 23 &&
-                        (appt.End.TimeOfDay == TimeSpan.Zero || appt.End.TimeOfDay >= new TimeSpan(23, 59, 0)))
+                var isAllDay = appt.Start.TimeOfDay == TimeSpan.Zero && span.TotalHours >= 23 &&
+                        (appt.End.TimeOfDay == TimeSpan.Zero || appt.End.TimeOfDay >= new TimeSpan(23, 59, 0));
+
+                if (isAllDay)
                 {
                         start = new CalDateTime(appt.Start.Date, tzId: null, hasTime: false);
                         var endDate = appt.End.TimeOfDay == TimeSpan.Zero ? appt.End.Date : appt.End.Date.AddDays(1);
@@ -514,9 +516,12 @@ public class CalendarSyncService : BackgroundService
                         Description = appt.Body ?? ""
                 };
 
-		// Reminders
-		calEvent.Alarms.Add(new Alarm { Action = AlarmAction.Display, Description = "Reminder", Trigger = new Trigger("-PT10M") });
-		calEvent.Alarms.Add(new Alarm { Action = AlarmAction.Display, Description = "Reminder", Trigger = new Trigger("-PT3M") });
+                // Reminders
+                if (!isAllDay)
+                {
+                        calEvent.Alarms.Add(new Alarm { Action = AlarmAction.Display, Description = "Reminder", Trigger = new Trigger("-PT10M") });
+                        calEvent.Alarms.Add(new Alarm { Action = AlarmAction.Display, Description = "Reminder", Trigger = new Trigger("-PT3M") });
+                }
 
 		return calEvent;
 	}


### PR DESCRIPTION
## Summary
- disable adding reminders for full-day and multi-day events
- document that reminders apply only to timed events

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b6c44e6c832bb5378f22b662f598