### PR TITLE
Implement manual full resync workflow from tray menu

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -29,10 +29,10 @@ public class Program
 			Application.Exit();
 		};
 
-		tray.WipeIosCalendarClicked += async (_, _) =>
-		{
-			await service.WipeEntireCalendarAsync();
-		};
+                tray.FullResyncClicked += async (_, _) =>
+                {
+                        await service.TriggerFullResyncAsync();
+                };
 
 		host.StartAsync().GetAwaiter().GetResult();
 		Application.Run();

--- a/src/TrayIconManager.cs
+++ b/src/TrayIconManager.cs
@@ -11,7 +11,7 @@ public sealed class TrayIconManager : IDisposable
         private readonly ContextMenuStrip _menu;
 
         public event EventHandler? ExitClicked;
-        public event EventHandler? WipeIosCalendarClicked;
+        public event EventHandler? FullResyncClicked;
 
 	public TrayIconManager()
 	{
@@ -41,18 +41,18 @@ public sealed class TrayIconManager : IDisposable
 		};
                 _menu.Items.Add(logsItem);
 
-                var wipeItem = new ToolStripMenuItem("Wipe iOS Calendar");
-                wipeItem.Click += (_, _) =>
+                var fullResyncItem = new ToolStripMenuItem("Full Re-Sync");
+                fullResyncItem.Click += (_, _) =>
                 {
                         var confirm = MessageBox.Show(
-                                "This will delete all events from the iCloud calendar. Continue?",
-                                "Confirm Wipe",
+                                "This will delete all events from the iCloud calendar and start a fresh sync. Continue?",
+                                "Confirm Full Re-Sync",
                                 MessageBoxButtons.YesNo,
                                 MessageBoxIcon.Warning);
                         if (confirm == DialogResult.Yes)
-                                WipeIosCalendarClicked?.Invoke(this, EventArgs.Empty);
+                                FullResyncClicked?.Invoke(this, EventArgs.Empty);
                 };
-                _menu.Items.Add(wipeItem);
+                _menu.Items.Add(fullResyncItem);
 
 		var exitItem = new ToolStripMenuItem("Exit");
 		exitItem.Click += (_, _) => ExitClicked?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
## Summary
- rename the tray menu action to "Full Re-Sync" with updated confirmation text
- add a manual full re-sync routine that wipes the calendar then runs the normal sync
- handle cancellation paths so manual re-syncs safely interrupt ongoing work and restart syncing

## Testing
- dotnet build *(fails: WindowsDesktop SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6236359d4832b85da556cae94dff6