### PR TITLE
Tighten single-instance guard formatting

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,9 @@ public class Program
 	public static void Main(string[] args)
 	{
 		EventRecorder.Initialize();
+		using var singleInstanceMutex = new System.Threading.Mutex(true, "CalendarSync", out var createdNewInstance);
+		if (!createdNewInstance)
+			return;
 		SubscribeToGlobalExceptions();
 		EventRecorder.WriteEntry("Application startup", EventLogEntryType.Information);
 


### PR DESCRIPTION
## Summary
- reference `System.Threading.Mutex` directly so no new using directive is needed
- keep the single-instance guard compact with tab-aligned indentation

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6838b185c832bbbc1e76b0ff07bde