### PR TITLE
Restore CalendarSync namespace references

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,3 @@
-﻿using CalendarSync.src;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;

--- a/src/CalendarSyncService.cs
+++ b/src/CalendarSyncService.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService : BackgroundService
 {

--- a/src/EventRecorder.cs
+++ b/src/EventRecorder.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public static class EventRecorder
 {

--- a/src/ICloud/ICloudCleanup.cs
+++ b/src/ICloud/ICloudCleanup.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/ICloud/ICloudSync.cs
+++ b/src/ICloud/ICloudSync.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using Ical.Net;
 using Ical.Net.Serialization;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/ICloud/ICloudUtilities.cs
+++ b/src/ICloud/ICloudUtilities.cs
@@ -4,7 +4,7 @@ using System.Xml.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/ICloud/ICloudVerification.cs
+++ b/src/ICloud/ICloudVerification.cs
@@ -4,7 +4,7 @@ using System.Text;
 using Ical.Net;
 using Ical.Net.CalendarComponents;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookEvents.cs
+++ b/src/Outlook/OutlookEvents.cs
@@ -1,7 +1,7 @@
 using System.Runtime.InteropServices;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookFetch.cs
+++ b/src/Outlook/OutlookFetch.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookInterop.cs
+++ b/src/Outlook/OutlookInterop.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookInteropProcess.cs
+++ b/src/Outlook/OutlookInteropProcess.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using Microsoft.Win32;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookRecurrence.cs
+++ b/src/Outlook/OutlookRecurrence.cs
@@ -4,7 +4,7 @@ using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookRecurrenceHelpers.cs
+++ b/src/Outlook/OutlookRecurrenceHelpers.cs
@@ -4,7 +4,7 @@ using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookRecurringHelpers.cs
+++ b/src/Outlook/OutlookRecurringHelpers.cs
@@ -1,7 +1,7 @@
 using System.Runtime.InteropServices;
 using Outlook = Microsoft.Office.Interop.Outlook;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/Outlook/OutlookTime.cs
+++ b/src/Outlook/OutlookTime.cs
@@ -1,4 +1,4 @@
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public partial class CalendarSyncService
 {

--- a/src/StaTask.cs
+++ b/src/StaTask.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public static class StaTask
 {

--- a/src/SyncConfig.cs
+++ b/src/SyncConfig.cs
@@ -1,4 +1,4 @@
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public class SyncConfig
 {

--- a/src/TrayIconManager.cs
+++ b/src/TrayIconManager.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 
-namespace CalendarSync.src;
+namespace CalendarSync;
 
 public sealed class TrayIconManager : IDisposable
 {


### PR DESCRIPTION
## Summary
- align all source files to use the CalendarSync namespace after the refactor
- remove obsolete CalendarSync.src using from Program.cs so hosted services resolve correctly

## Testing
- dotnet build *(fails: WindowsDesktop targets unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f12f53d258832bac161356f3ca6cd7