### PR TITLE
Ensure logging extensions available in partial service files

### DIFF
--- a/src/ICloud/ICloudCleanup.cs
+++ b/src/ICloud/ICloudCleanup.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/ICloud/ICloudSync.cs
+++ b/src/ICloud/ICloudSync.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using Ical.Net;
 using Ical.Net.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/ICloud/ICloudUtilities.cs
+++ b/src/ICloud/ICloudUtilities.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Xml.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/ICloud/ICloudVerification.cs
+++ b/src/ICloud/ICloudVerification.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text;
 using Ical.Net;
 using Ical.Net.CalendarComponents;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/Outlook/OutlookEvents.cs
+++ b/src/Outlook/OutlookEvents.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Outlook = Microsoft.Office.Interop.Outlook;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/Outlook/OutlookFetch.cs
+++ b/src/Outlook/OutlookFetch.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Threading;
 using Outlook = Microsoft.Office.Interop.Outlook;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/Outlook/OutlookInterop.cs
+++ b/src/Outlook/OutlookInterop.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Threading;
 using Outlook = Microsoft.Office.Interop.Outlook;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/Outlook/OutlookInteropProcess.cs
+++ b/src/Outlook/OutlookInteropProcess.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Win32;
 using Outlook = Microsoft.Office.Interop.Outlook;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/Outlook/OutlookRecurrenceHelpers.cs
+++ b/src/Outlook/OutlookRecurrenceHelpers.cs
@@ -3,6 +3,7 @@ using Ical.Net;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Outlook = Microsoft.Office.Interop.Outlook;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/Outlook/OutlookRecurringHelpers.cs
+++ b/src/Outlook/OutlookRecurringHelpers.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Outlook = Microsoft.Office.Interop.Outlook;
+using Microsoft.Extensions.Logging;
 
 namespace CalendarSync;
 

--- a/src/Outlook/OutlookTime.cs
+++ b/src/Outlook/OutlookTime.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace CalendarSync;
 
 public partial class CalendarSyncService


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.Logging imports to each CalendarSyncService partial file that uses the shared logger field
- ensure logging extension methods are available after refactoring into separate files

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f130f1c540832ba1aa26d28e45b848