### PR TITLE
Add diagnostics namespace to iCloud partials

### DIFF
--- a/src/ICloud/ICloudSync.cs
+++ b/src/ICloud/ICloudSync.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Text;

--- a/src/ICloud/ICloudUtilities.cs
+++ b/src/ICloud/ICloudUtilities.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;

--- a/src/ICloud/ICloudVerification.cs
+++ b/src/ICloud/ICloudVerification.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Text;


### PR DESCRIPTION
## Summary
- import System.Diagnostics in iCloud partial classes so EventLogEntryType resolves after the refactor

## Testing
- dotnet build *(fails: WindowsDesktop targeting pack is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f133d97e18832babdbb33f482be14c