### PR TITLE
Simplify recurrence expansion and recurrence helpers

### DIFF
--- a/src/Outlook/OutlookRecurrence.cs
+++ b/src/Outlook/OutlookRecurrence.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Ical.Net;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
@@ -8,43 +7,62 @@ namespace CalendarSync;
 
 public partial class CalendarSyncService
 {
-	private List<(string uid, DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)> ExpandRecurrenceManually(Outlook.AppointmentItem appt, DateTime from, DateTime to)
+	private List<(DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)> ExpandRecurrenceManually(Outlook.AppointmentItem appt, DateTime from, DateTime to)
+	{
+		var results = new List<(DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)>();
+
+		var pattern = TryGetRecurrencePattern(appt);
+		if (pattern == null)
 		{
-			var results = new List<(string uid, DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)>();
-
-			var pattern = TryGetRecurrencePattern(appt);
-			if (pattern == null)
-			{
-				return results;
-			}
-
-			var rule = BuildRecurrenceRule(pattern, appt.Subject);
-			if (rule == null)
-			{
-				return results;
-			}
-
-			var (baseStartLocal, baseStartUtc) = NormalizeOutlookTimes(appt.Start, appt.StartUTC, $"series '{appt.Subject}' start");
-			var (baseEndLocal, baseEndUtc) = NormalizeOutlookTimes(appt.End, appt.EndUTC, $"series '{appt.Subject}' end");
-
-			var (_, masterStart, masterEnd, apptIsMaster) = ResolveSeriesContext(appt, pattern, baseStartLocal, baseEndLocal);
-			var (calEvent, baseDuration) = CreateRecurrenceCalendarEvent(
-			rule,
-			baseStartLocal,
-			baseStartUtc,
-			baseEndUtc,
-			masterStart,
-			masterEnd,
-			pattern,
-			appt,
-			apptIsMaster);
-
-			var skipDates = new HashSet<DateTime>();
-			ProcessRecurrenceExceptions(pattern, appt, from, to, results, skipDates);
-
-			var occurrences = calEvent.GetOccurrences(ConvertFromSourceLocalToUtc(from), ConvertFromSourceLocalToUtc(to));
-			AddCalculatedOccurrences(results, appt, occurrences, skipDates, baseDuration, appt.AllDayEvent);
-
 			return results;
 		}
+
+		var rule = BuildRecurrenceRule(pattern, appt.Subject);
+		if (rule == null)
+		{
+			return results;
+		}
+
+		var (baseStartLocal, baseStartUtc) = NormalizeOutlookTimes(appt.Start, appt.StartUTC, $"series '{appt.Subject}' start");
+		var (baseEndLocal, baseEndUtc) = NormalizeOutlookTimes(appt.End, appt.EndUTC, $"series '{appt.Subject}' end");
+		var seriesAllDay = DetermineAllDay(baseStartLocal, baseEndLocal, appt.AllDayEvent);
+		var baseDuration = baseEndUtc - baseStartUtc;
+		if (baseDuration <= TimeSpan.Zero)
+		{
+			_logger.LogWarning("Recurrence duration invalid for '{Subject}'. Falling back to 30 minutes.", appt.Subject);
+			baseDuration = TimeSpan.FromMinutes(30);
+		}
+
+		CalDateTime startCal;
+		CalDateTime endCal;
+		if (seriesAllDay)
+		{
+			var (startDate, endDate) = GetAllDayDateRange(baseStartLocal, baseEndLocal);
+			startCal = new CalDateTime(startDate.Year, startDate.Month, startDate.Day) { IsAllDay = true };
+			endCal = new CalDateTime(endDate.Year, endDate.Month, endDate.Day) { IsAllDay = true };
+		}
+		else
+		{
+			startCal = new CalDateTime(baseStartUtc) { IsUniversalTime = true };
+			endCal = new CalDateTime(baseEndUtc) { IsUniversalTime = true };
+		}
+
+		var calEvent = new CalendarEvent
+		{
+			Start = startCal,
+			End = endCal,
+			RecurrenceRules = new List<RecurrencePattern> { rule },
+			IsAllDay = seriesAllDay
+		};
+
+		var skipDates = new HashSet<DateTime>();
+		ProcessRecurrenceExceptions(pattern, appt, from, to, results, skipDates);
+
+		var utcFrom = ConvertFromSourceLocalToUtc(from);
+		var utcTo = ConvertFromSourceLocalToUtc(to);
+		var occurrences = calEvent.GetOccurrences(utcFrom, utcTo);
+		AddCalculatedOccurrences(results, appt, occurrences, skipDates, baseDuration, seriesAllDay);
+
+		return results;
 	}
+}

--- a/src/Outlook/OutlookRecurrenceHelpers.cs
+++ b/src/Outlook/OutlookRecurrenceHelpers.cs
@@ -2,8 +2,8 @@ using System.Runtime.InteropServices;
 using Ical.Net;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
-using Outlook = Microsoft.Office.Interop.Outlook;
 using Microsoft.Extensions.Logging;
+using Outlook = Microsoft.Office.Interop.Outlook;
 
 namespace CalendarSync;
 
@@ -24,30 +24,39 @@ public partial class CalendarSyncService
 
 	private RecurrencePattern? BuildRecurrenceRule(Outlook.RecurrencePattern pattern, string? subject)
 	{
-		var freq = pattern.RecurrenceType switch
-		{
-			Outlook.OlRecurrenceType.olRecursDaily => FrequencyType.Daily,
-			Outlook.OlRecurrenceType.olRecursWeekly => FrequencyType.Weekly,
-			Outlook.OlRecurrenceType.olRecursMonthly => FrequencyType.Monthly,
-			Outlook.OlRecurrenceType.olRecursYearly => FrequencyType.Yearly,
-			_ => FrequencyType.None
-		};
-
-		if (freq == FrequencyType.None)
-		{
-			_logger.LogWarning("Unsupported recurrence type for event '{Subject}'. Skipping.", subject);
-			return null;
-		}
-
 		var rule = new RecurrencePattern
 		{
-			Frequency = freq,
-			Interval = pattern.Interval
+			Interval = Math.Max(1, pattern.Interval)
 		};
 
-		if (freq == FrequencyType.Weekly)
+		switch (pattern.RecurrenceType)
 		{
-			ConfigureWeeklyRule(rule, pattern.DayOfWeekMask);
+			case Outlook.OlRecurrenceType.olRecursDaily:
+				rule.Frequency = FrequencyType.Daily;
+				break;
+			case Outlook.OlRecurrenceType.olRecursWeekly:
+				rule.Frequency = FrequencyType.Weekly;
+				ConfigureWeeklyRule(rule, pattern.DayOfWeekMask);
+				break;
+			case Outlook.OlRecurrenceType.olRecursMonthly:
+				rule.Frequency = FrequencyType.Monthly;
+				ConfigureMonthlyRule(rule, pattern.DayOfMonth);
+				break;
+			case Outlook.OlRecurrenceType.olRecursMonthNth:
+				rule.Frequency = FrequencyType.Monthly;
+				ConfigureNthRule(rule, pattern.DayOfWeekMask, pattern.Instance);
+				break;
+			case Outlook.OlRecurrenceType.olRecursYearly:
+				rule.Frequency = FrequencyType.Yearly;
+				ConfigureYearlyRule(rule, pattern.MonthOfYear, pattern.DayOfMonth);
+				break;
+			case Outlook.OlRecurrenceType.olRecursYearNth:
+				rule.Frequency = FrequencyType.Yearly;
+				ConfigureYearlyNthRule(rule, pattern.MonthOfYear, pattern.DayOfWeekMask, pattern.Instance);
+				break;
+			default:
+				_logger.LogWarning("Unsupported recurrence type for event '{Subject}'. Skipping.", subject);
+				return null;
 		}
 
 		ApplyPatternEnd(rule, pattern);
@@ -56,36 +65,110 @@ public partial class CalendarSyncService
 
 	private void ConfigureWeeklyRule(RecurrencePattern rule, Outlook.OlDaysOfWeek mask)
 	{
+		var byDay = GetWeekDaysFromMask(mask, null);
+		if (byDay.Count == 0)
+		{
+			return;
+		}
+		rule.ByDay = byDay;
+	}
+
+	private void ConfigureMonthlyRule(RecurrencePattern rule, int dayOfMonth)
+	{
+		if (dayOfMonth >= 1 && dayOfMonth <= 31)
+		{
+			rule.ByMonthDay = new List<int> { dayOfMonth };
+		}
+	}
+
+	private void ConfigureNthRule(RecurrencePattern rule, Outlook.OlDaysOfWeek mask, int instance)
+	{
+		var occurrence = NormalizeInstance(instance);
+		var byDay = GetWeekDaysFromMask(mask, occurrence);
+		if (byDay.Count == 0)
+		{
+			return;
+		}
+		rule.ByDay = byDay;
+	}
+
+	private void ConfigureYearlyRule(RecurrencePattern rule, int monthOfYear, int dayOfMonth)
+	{
+		if (monthOfYear >= 1 && monthOfYear <= 12)
+		{
+			rule.ByMonth = new List<int> { monthOfYear };
+		}
+		if (dayOfMonth >= 1 && dayOfMonth <= 31)
+		{
+			rule.ByMonthDay = new List<int> { dayOfMonth };
+		}
+	}
+
+	private void ConfigureYearlyNthRule(RecurrencePattern rule, int monthOfYear, Outlook.OlDaysOfWeek mask, int instance)
+	{
+		if (monthOfYear >= 1 && monthOfYear <= 12)
+		{
+			rule.ByMonth = new List<int> { monthOfYear };
+		}
+		var occurrence = NormalizeInstance(instance);
+		var byDay = GetWeekDaysFromMask(mask, occurrence);
+		if (byDay.Count == 0)
+		{
+			return;
+		}
+		rule.ByDay = byDay;
+	}
+
+	private List<WeekDay> GetWeekDaysFromMask(Outlook.OlDaysOfWeek mask, int? occurrence)
+	{
 		var byDay = new List<WeekDay>();
+		void Add(DayOfWeek day)
+		{
+			var weekDay = occurrence.HasValue && occurrence.Value != 0
+				? new WeekDay(day, occurrence.Value)
+				: new WeekDay(day);
+			byDay.Add(weekDay);
+		}
+
 		if ((mask & Outlook.OlDaysOfWeek.olMonday) != 0)
 		{
-			byDay.Add(new WeekDay(DayOfWeek.Monday));
+			Add(DayOfWeek.Monday);
 		}
 		if ((mask & Outlook.OlDaysOfWeek.olTuesday) != 0)
 		{
-			byDay.Add(new WeekDay(DayOfWeek.Tuesday));
+			Add(DayOfWeek.Tuesday);
 		}
 		if ((mask & Outlook.OlDaysOfWeek.olWednesday) != 0)
 		{
-			byDay.Add(new WeekDay(DayOfWeek.Wednesday));
+			Add(DayOfWeek.Wednesday);
 		}
 		if ((mask & Outlook.OlDaysOfWeek.olThursday) != 0)
 		{
-			byDay.Add(new WeekDay(DayOfWeek.Thursday));
+			Add(DayOfWeek.Thursday);
 		}
 		if ((mask & Outlook.OlDaysOfWeek.olFriday) != 0)
 		{
-			byDay.Add(new WeekDay(DayOfWeek.Friday));
+			Add(DayOfWeek.Friday);
 		}
 		if ((mask & Outlook.OlDaysOfWeek.olSaturday) != 0)
 		{
-			byDay.Add(new WeekDay(DayOfWeek.Saturday));
+			Add(DayOfWeek.Saturday);
 		}
 		if ((mask & Outlook.OlDaysOfWeek.olSunday) != 0)
 		{
-			byDay.Add(new WeekDay(DayOfWeek.Sunday));
+			Add(DayOfWeek.Sunday);
 		}
-		rule.ByDay = byDay;
+
+		return byDay;
+	}
+
+	private int NormalizeInstance(int instance)
+	{
+		if (instance <= 0)
+		{
+			return 0;
+		}
+		return instance == 5 ? -1 : instance;
 	}
 
 	private void ApplyPatternEnd(RecurrencePattern rule, Outlook.RecurrencePattern pattern)
@@ -105,257 +188,60 @@ public partial class CalendarSyncService
 		}
 	}
 
-	private (Outlook.AppointmentItem seriesItem, DateTime? masterStart, DateTime? masterEnd, bool apptIsMaster) ResolveSeriesContext(
-	Outlook.AppointmentItem appt,
-	Outlook.RecurrencePattern pattern,
-	DateTime baseStartLocal,
-	DateTime baseEndLocal)
-	{
-		var apptIsMaster = false;
-		try
-		{
-			apptIsMaster = appt.RecurrenceState == Outlook.OlRecurrenceState.olApptMaster;
-		}
-		catch (COMException)
-		{
-		}
-
-		Outlook.AppointmentItem seriesItem = appt;
-		Outlook.AppointmentItem? master = null;
-		var releaseMaster = false;
-		DateTime? masterStart = null;
-		DateTime? masterEnd = null;
-
-		if (!apptIsMaster)
-		{
-			try
-			{
-				master = pattern.Parent as Outlook.AppointmentItem;
-				if (master != null && !ReferenceEquals(master, appt))
-				{
-					releaseMaster = true;
-					try
-					{
-						var (resolvedStart, _) = NormalizeOutlookTimes(master.Start, master.StartUTC, $"master '{appt.Subject}' start");
-						var (resolvedEnd, _) = NormalizeOutlookTimes(master.End, master.EndUTC, $"master '{appt.Subject}' end");
-						masterStart = resolvedStart;
-						masterEnd = resolvedEnd;
-					}
-					catch (COMException)
-					{
-						masterStart = null;
-						masterEnd = null;
-					}
-					seriesItem = master;
-				}
-				else if (master != null)
-				{
-					masterStart = baseStartLocal;
-					masterEnd = baseEndLocal;
-				}
-			}
-			catch (COMException)
-			{
-			}
-			finally
-			{
-				if (releaseMaster && master != null)
-				{
-					try
-					{
-						Marshal.ReleaseComObject(master);
-					}
-					catch
-					{
-					}
-				}
-			}
-		}
-
-		return (seriesItem, masterStart, masterEnd, apptIsMaster);
-	}
-
-	private (CalendarEvent calEvent, TimeSpan baseDuration) CreateRecurrenceCalendarEvent(
-	RecurrencePattern rule,
-	DateTime baseStartLocal,
-	DateTime baseStartUtc,
-	DateTime baseEndUtc,
-	DateTime? masterStart,
-	DateTime? masterEnd,
-	Outlook.RecurrencePattern pattern,
-	Outlook.AppointmentItem appt,
-	bool apptIsMaster)
-	{
-		DateTime? patternSeriesStart = null;
-		try
-		{
-			if (pattern.PatternStartDate != DateTime.MinValue)
-			{
-				var startDate = pattern.PatternStartDate.Date;
-				var timeOfDay = pattern.StartTime != DateTime.MinValue
-				? pattern.StartTime.TimeOfDay
-				: (masterStart ?? baseStartLocal).TimeOfDay;
-				patternSeriesStart = startDate.Add(timeOfDay);
-			}
-		}
-		catch (COMException)
-		{
-		}
-
-		var hasPatternSeriesStart = patternSeriesStart.HasValue && patternSeriesStart.Value.Year >= 1900;
-		if (!hasPatternSeriesStart)
-		{
-			patternSeriesStart = null;
-		}
-
-		var seriesStart = patternSeriesStart ?? masterStart ?? baseStartLocal;
-		var (baseDuration, adjustedSeriesStart) = CalculateBaseDuration(
-		pattern,
-		masterStart,
-		masterEnd,
-		apptIsMaster,
-		baseStartLocal,
-		baseStartUtc,
-		baseEndUtc,
-		hasPatternSeriesStart,
-		seriesStart);
-		seriesStart = adjustedSeriesStart;
-
-		if (seriesStart == DateTime.MinValue || seriesStart.Year < 1900)
-		{
-			seriesStart = baseStartLocal;
-		}
-
-		var seriesEnd = seriesStart.Add(baseDuration);
-		var seriesStartUtc = ConvertFromSourceLocalToUtc(seriesStart, $"series '{appt.Subject}' anchor start");
-		var seriesEndUtc = ConvertFromSourceLocalToUtc(seriesEnd, $"series '{appt.Subject}' anchor end");
-
-		var calEvent = new CalendarEvent
-		{
-			Start = new CalDateTime(seriesStartUtc),
-			End = new CalDateTime(seriesEndUtc),
-			RecurrenceRules = new List<RecurrencePattern> { rule }
-		};
-
-		return (calEvent, baseDuration);
-	}
-
-	private (TimeSpan baseDuration, DateTime seriesStart) CalculateBaseDuration(
-	Outlook.RecurrencePattern pattern,
-	DateTime? masterStart,
-	DateTime? masterEnd,
-	bool apptIsMaster,
-	DateTime baseStartLocal,
-	DateTime baseStartUtc,
-	DateTime baseEndUtc,
-	bool hasPatternSeriesStart,
-	DateTime seriesStart)
-	{
-		var baseDuration = TimeSpan.Zero;
-
-		if (pattern.StartTime != DateTime.MinValue && pattern.EndTime != DateTime.MinValue)
-		{
-			var candidate = pattern.EndTime - pattern.StartTime;
-			if (candidate > TimeSpan.Zero)
-			{
-				baseDuration = candidate;
-			}
-		}
-
-		if (baseDuration <= TimeSpan.Zero && masterStart.HasValue && masterEnd.HasValue)
-		{
-			var candidate = masterEnd.Value - masterStart.Value;
-			if (candidate > TimeSpan.Zero)
-			{
-				if (!hasPatternSeriesStart)
-				{
-					seriesStart = masterStart.Value;
-				}
-				baseDuration = candidate;
-			}
-		}
-
-		if (baseDuration <= TimeSpan.Zero && apptIsMaster)
-		{
-			var candidate = baseEndUtc - baseStartUtc;
-			if (candidate > TimeSpan.Zero)
-			{
-				if (!hasPatternSeriesStart)
-				{
-					seriesStart = baseStartLocal;
-				}
-				baseDuration = candidate;
-			}
-		}
-
-		if (baseDuration <= TimeSpan.Zero)
-		{
-			var candidate = baseEndUtc - baseStartUtc;
-			if (candidate > TimeSpan.Zero)
-			{
-				baseDuration = candidate;
-			}
-		}
-
-		return (baseDuration, seriesStart);
-	}
-
 	private void ProcessRecurrenceExceptions(
 		Outlook.RecurrencePattern pattern,
 		Outlook.AppointmentItem appt,
 		DateTime from,
 		DateTime to,
-		List<(string uid, DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)> results,
+		List<(DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)> results,
 		HashSet<DateTime> skipDates)
+	{
+		foreach (Outlook.Exception ex in pattern.Exceptions)
 		{
-			foreach (Outlook.Exception ex in pattern.Exceptions)
+			try
 			{
-				try
+				skipDates.Add(ex.OriginalDate.Date);
+
+				if (ex.AppointmentItem != null)
 				{
-					skipDates.Add(ex.OriginalDate.Date);
+					var (exStartLocal, exStartUtc) = NormalizeOutlookTimes(ex.AppointmentItem.Start, ex.AppointmentItem.StartUTC, $"exception '{appt.Subject}' start");
+					var (exEndLocal, exEndUtc) = NormalizeOutlookTimes(ex.AppointmentItem.End, ex.AppointmentItem.EndUTC, $"exception '{appt.Subject}' end");
 
-					if (ex.AppointmentItem != null)
+					if (exStartLocal >= from && exStartLocal <= to)
 					{
-						var (exStartLocal, exStartUtc) = NormalizeOutlookTimes(ex.AppointmentItem.Start, ex.AppointmentItem.StartUTC, $"exception '{appt.Subject}' start");
-						var (exEndLocal, exEndUtc) = NormalizeOutlookTimes(ex.AppointmentItem.End, ex.AppointmentItem.EndUTC, $"exception '{appt.Subject}' end");
-
-						if (exStartLocal >= from && exStartLocal <= to)
-						{
-							var exUid = $"outlook-{appt.GlobalAppointmentID}-{exStartLocal:yyyyMMddTHHmmss}";
-							var exAllDay = DetermineAllDay(exStartLocal, exEndLocal, ex.AppointmentItem?.AllDayEvent ?? appt.AllDayEvent);
-							results.Add((exUid, exStartLocal, exEndLocal, exStartUtc, exEndUtc, exAllDay));
-							_logger.LogInformation("Processed modified occurrence for '{Subject}' at {Start}", appt.Subject, exStartLocal);
-						}
+						var exAllDay = DetermineAllDay(exStartLocal, exEndLocal, ex.AppointmentItem?.AllDayEvent ?? appt.AllDayEvent);
+						results.Add((exStartLocal, exEndLocal, exStartUtc, exEndUtc, exAllDay));
+						_logger.LogInformation("Processed modified occurrence for '{Subject}' at {Start}", appt.Subject, exStartLocal);
 					}
 				}
-				catch
-				{
-				}
+			}
+			catch
+			{
 			}
 		}
+	}
 
 	private void AddCalculatedOccurrences(
-		List<(string uid, DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)> results,
+		List<(DateTime startLocal, DateTime endLocal, DateTime startUtc, DateTime endUtc, bool isAllDay)> results,
 		Outlook.AppointmentItem appt,
 		IEnumerable<Occurrence> occurrences,
 		HashSet<DateTime> skipDates,
 		TimeSpan baseDuration,
 		bool seriesAllDay)
+	{
+		foreach (var occ in occurrences)
 		{
-			foreach (var occ in occurrences)
+			var startUtc = DateTime.SpecifyKind(occ.Period.StartTime.AsUtc, DateTimeKind.Utc);
+			var endUtc = DateTime.SpecifyKind(occ.Period.EndTime?.AsUtc ?? startUtc.Add(baseDuration), DateTimeKind.Utc);
+			var startLocal = ConvertUtcToSourceLocal(startUtc);
+			var endLocal = ConvertUtcToSourceLocal(endUtc);
+			if (skipDates.Contains(startLocal.Date))
 			{
-				var startUtc = DateTime.SpecifyKind(occ.Period.StartTime.AsUtc, DateTimeKind.Utc);
-				var endUtc = DateTime.SpecifyKind(occ.Period.EndTime?.AsUtc ?? startUtc.Add(baseDuration), DateTimeKind.Utc);
-				var startLocal = ConvertUtcToSourceLocal(startUtc);
-				var endLocal = ConvertUtcToSourceLocal(endUtc);
-				if (skipDates.Contains(startLocal.Date))
-				{
-					continue;
-				}
-
-				var uid = $"outlook-{appt.GlobalAppointmentID}-{startLocal:yyyyMMddTHHmmss}";
-				var occAllDay = DetermineAllDay(startLocal, endLocal, seriesAllDay);
-				results.Add((uid, startLocal, endLocal, startUtc, endUtc, occAllDay));
+				continue;
 			}
+
+			var occAllDay = DetermineAllDay(startLocal, endLocal, seriesAllDay);
+			results.Add((startLocal, endLocal, startUtc, endUtc, occAllDay));
 		}
 	}
+}

--- a/src/Outlook/OutlookRecurringHelpers.cs
+++ b/src/Outlook/OutlookRecurringHelpers.cs
@@ -12,50 +12,56 @@ public partial class CalendarSyncService
 		HashSet<string> expandedRecurringIds,
 		DateTime syncStart,
 		DateTime syncEnd)
+	{
+		Outlook.AppointmentItem seriesItem = appt;
+		Outlook.AppointmentItem? masterItem = null;
+		var shouldReleaseMaster = false;
+		var globalId = appt.GlobalAppointmentID;
+
+		var recurrenceState = Outlook.OlRecurrenceState.olApptMaster;
+		try
 		{
-			Outlook.AppointmentItem seriesItem = appt;
-			Outlook.AppointmentItem? masterItem = null;
-			var shouldReleaseMaster = false;
-			var globalId = appt.GlobalAppointmentID;
+			recurrenceState = appt.RecurrenceState;
+		}
+		catch (COMException ex)
+		{
+			_logger.LogDebug(ex, "Failed to read recurrence state for '{Subject}'. Assuming master.", appt.Subject);
+		}
 
-			var recurrenceState = Outlook.OlRecurrenceState.olApptMaster;
-			try
-			{
-				recurrenceState = appt.RecurrenceState;
-			}
-			catch (COMException ex)
-			{
-				_logger.LogDebug(ex, "Failed to read recurrence state for '{Subject}'. Assuming master.", appt.Subject);
-			}
+		if (recurrenceState != Outlook.OlRecurrenceState.olApptMaster)
+		{
+			(seriesItem, masterItem, shouldReleaseMaster, globalId) = ResolveMasterAppointment(appt, globalId);
+		}
 
-			if (recurrenceState != Outlook.OlRecurrenceState.olApptMaster)
-			{
-				(seriesItem, masterItem, shouldReleaseMaster, globalId) = ResolveMasterAppointment(appt, globalId);
-			}
-
-			if (string.IsNullOrEmpty(globalId))
+		if (string.IsNullOrEmpty(globalId))
+		{
 			globalId = appt.GlobalAppointmentID;
+		}
 
-			if (string.IsNullOrEmpty(globalId))
+		if (string.IsNullOrEmpty(globalId))
+		{
 			globalId = Guid.NewGuid().ToString();
+		}
 
-			if (!expandedRecurringIds.Add(globalId))
+		if (!expandedRecurringIds.Add(globalId))
+		{
+			ReleaseIfNeeded(masterItem, shouldReleaseMaster);
+			return;
+		}
+
+		var patternStart = syncStart.AddDays(-_config.RecurrenceExpansionDaysPast);
+		var patternEnd = syncEnd.AddDays(_config.RecurrenceExpansionDaysFuture);
+
+		var occurrences = ExpandRecurrenceManually(seriesItem, patternStart, patternEnd);
+
+		foreach (var (startLocal, endLocal, startUtc, endUtc, isAllDay) in occurrences)
+		{
+			if (startLocal < syncStart || startLocal > syncEnd)
 			{
-				ReleaseIfNeeded(masterItem, shouldReleaseMaster);
-				return;
+				continue;
 			}
 
-			var patternStart = syncStart.AddDays(-_config.RecurrenceExpansionDaysPast);
-			var patternEnd = syncEnd.AddDays(_config.RecurrenceExpansionDaysFuture);
-
-			var occurrences = ExpandRecurrenceManually(seriesItem, patternStart, patternEnd);
-
-			foreach (var (uid, startLocal, endLocal, startUtc, endUtc, isAllDay) in occurrences)
-			{
-				if (startLocal < syncStart || startLocal > syncEnd)
-				continue;
-
-				var dto = new OutlookEventDto(
+			var dto = new OutlookEventDto(
 				appt.Subject ?? string.Empty,
 				appt.Body ?? string.Empty,
 				appt.Location ?? string.Empty,
@@ -65,62 +71,64 @@ public partial class CalendarSyncService
 				endUtc,
 				globalId,
 				isAllDay
-				);
+			);
 
-				dto = EnsureEventConsistency(dto, $"recurring '{appt.Subject}'");
-				var sanitizedDto = dto with { StartLocal = dto.StartLocal, EndLocal = dto.EndLocal };
-				AddEventChunks(events, globalId, sanitizedDto);
-			}
-
-			ReleaseIfNeeded(masterItem, shouldReleaseMaster);
+			dto = EnsureEventConsistency(dto, $"recurring '{appt.Subject}'");
+			var sanitizedDto = dto with { StartLocal = dto.StartLocal, EndLocal = dto.EndLocal };
+			AddEventChunks(events, globalId, sanitizedDto);
 		}
+
+		ReleaseIfNeeded(masterItem, shouldReleaseMaster);
+	}
 
 	private (Outlook.AppointmentItem seriesItem, Outlook.AppointmentItem? masterItem, bool shouldRelease, string globalId) ResolveMasterAppointment(Outlook.AppointmentItem appt, string globalId)
-		{
-			Outlook.AppointmentItem? masterItem = null;
-			var shouldReleaseMaster = false;
-			Outlook.AppointmentItem seriesItem = appt;
+	{
+		Outlook.AppointmentItem? masterItem = null;
+		var shouldReleaseMaster = false;
+		Outlook.AppointmentItem seriesItem = appt;
 
-			try
+		try
+		{
+			var pattern = appt.GetRecurrencePattern();
+			if (pattern?.Parent is Outlook.AppointmentItem parent)
 			{
-				var pattern = appt.GetRecurrencePattern();
-				if (pattern?.Parent is Outlook.AppointmentItem parent)
+				masterItem = parent;
+				if (!ReferenceEquals(parent, appt))
 				{
-					masterItem = parent;
-					if (!ReferenceEquals(parent, appt))
-					{
-						shouldReleaseMaster = true;
-						seriesItem = parent;
-					}
-					try
-					{
-						if (!string.IsNullOrEmpty(parent.GlobalAppointmentID))
-						globalId = parent.GlobalAppointmentID;
-					}
-					catch (COMException)
-					{
-					}
+					shouldReleaseMaster = true;
+					seriesItem = parent;
 				}
-			}
-			catch (COMException ex)
-			{
-				_logger.LogDebug(ex, "Failed to resolve master item for '{Subject}'.", appt.Subject);
-			}
-
-			return (seriesItem, masterItem, shouldReleaseMaster, globalId);
-		}
-
-	private void ReleaseIfNeeded(Outlook.AppointmentItem? masterItem, bool shouldReleaseMaster)
-		{
-			if (shouldReleaseMaster && masterItem != null)
-			{
 				try
 				{
-					Marshal.FinalReleaseComObject(masterItem);
+					if (!string.IsNullOrEmpty(parent.GlobalAppointmentID))
+					{
+						globalId = parent.GlobalAppointmentID;
+					}
 				}
-				catch
+				catch (COMException)
 				{
 				}
+			}
+		}
+		catch (COMException ex)
+		{
+			_logger.LogDebug(ex, "Failed to resolve master item for '{Subject}'.", appt.Subject);
+		}
+
+		return (seriesItem, masterItem, shouldReleaseMaster, globalId);
+	}
+
+	private void ReleaseIfNeeded(Outlook.AppointmentItem? masterItem, bool shouldReleaseMaster)
+	{
+		if (shouldReleaseMaster && masterItem != null)
+		{
+			try
+			{
+				Marshal.FinalReleaseComObject(masterItem);
+			}
+			catch
+			{
 			}
 		}
 	}
+}


### PR DESCRIPTION
## Summary
- streamline recurrence expansion to compute base durations and anchors directly, including explicit all-day handling
- refactor recurrence helper utilities to map Outlook patterns into complete iCal rules and process exceptions consistently
- update recurring sync flow to consume the simplified occurrence tuples while keeping master resolution safeguards

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1f31b06d4832bb97314dcb8c75922