### PR TITLE
Fix iCloud calendar compatibility issues

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using Serilog;
 using Serilog.Events;
 using System.Diagnostics;
+using System.Windows.Forms;
 
 namespace CalendarSync;
 
@@ -26,15 +27,15 @@ public class Program
 		tray.ExitClicked += async (_, _) =>
 		{
 			EventRecorder.WriteEntry("Shutdown requested", EventLogEntryType.Information);
-			await host.StopAsync();
+			await host.StopAsync().ConfigureAwait(false);
 			tray.Dispose();
 			Application.Exit();
 		};
 
-                tray.FullResyncClicked += async (_, _) =>
-                {
-                        await service.TriggerFullResyncAsync();
-                };
+		tray.FullResyncClicked += async (_, _) =>
+		{
+			await service.TriggerFullResyncAsync().ConfigureAwait(false);
+		};
 
 		host.StartAsync().GetAwaiter().GetResult();
 		Application.Run();

--- a/src/ICloud/ICloudUtilities.cs
+++ b/src/ICloud/ICloudUtilities.cs
@@ -22,9 +22,9 @@ public partial class CalendarSyncService
 
 	try
 	{
-		var response = await client.SendAsync(request);
+		var response = await client.SendAsync(request).ConfigureAwait(false);
 		response.EnsureSuccessStatusCode();
-		var content = await response.Content.ReadAsStringAsync();
+		var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 		var document = XDocument.Parse(content);
 
 		XNamespace dav = "DAV:";
@@ -71,13 +71,13 @@ return events;
 			if (isAllDay)
 			{
 				var (startDate, endDate) = GetAllDayDateRange(appt.StartLocal, appt.EndLocal);
-				start = new CalDateTime(startDate.Year, startDate.Month, startDate.Day) { IsAllDay = true };
-				end = new CalDateTime(endDate.Year, endDate.Month, endDate.Day) { IsAllDay = true };
+				start = new CalDateTime(startDate);
+				end = new CalDateTime(endDate);
 			}
 			else
 			{
-				start = new CalDateTime(appt.StartUtc) { IsUniversalTime = true };
-				end = new CalDateTime(appt.EndUtc) { IsUniversalTime = true };
+				start = new CalDateTime(appt.StartUtc, CalDateTime.UtcTzId);
+				end = new CalDateTime(appt.EndUtc, CalDateTime.UtcTzId);
 			}
 
 			var calEvent = new CalendarEvent
@@ -90,9 +90,7 @@ return events;
 				Description = appt.Body ?? string.Empty,
 			};
 
-			calEvent.IsAllDay = isAllDay;
-
-			if (!isAllDay)
+				if (!isAllDay)
 			{
 				calEvent.Alarms.Add(new Alarm { Action = AlarmAction.Display, Description = "Reminder", Trigger = new Trigger("-PT10M") });
 				calEvent.Alarms.Add(new Alarm { Action = AlarmAction.Display, Description = "Reminder", Trigger = new Trigger("-PT3M") });

--- a/src/ICloud/ICloudVerification.cs
+++ b/src/ICloud/ICloudVerification.cs
@@ -84,7 +84,7 @@ private async Task AttemptICloudCorrectionAsync(HttpClient client, string eventU
 			return;
 		}
 
-	var verified = await VerifyICloudEventAsync(client, eventUrl, dto, token);
+	var verified = await VerifyICloudEventAsync(client, eventUrl, dto, token).ConfigureAwait(false);
 	if (verified)
 	{
 		_logger.LogInformation("Verification succeeded after correction for UID {Uid}", uid);
@@ -127,7 +127,7 @@ private void LogVerificationFailure(string uid, string message)
 
 	private static (DateTime start, DateTime end, bool isAllDay) GetActualTimes(CalendarEvent calEvent)
 		{
-			var isAllDay = calEvent.Start?.IsAllDay ?? false;
+			var isAllDay = calEvent.IsAllDay;
 			if (isAllDay)
 			{
 				var startDate = calEvent.Start?.Value.Date ?? DateTime.MinValue.Date;


### PR DESCRIPTION
## Summary
- ensure the WinForms host setup uses the Windows Forms namespace and avoids capturing the UI thread when shutting down
- update iCloud calendar event creation and verification to follow the current Ical.Net 5 API, removing invalid property assignments

## Testing
- not run (requires Microsoft.NET.Sdk.WindowsDesktop which is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68f1fba16618832b95e1c38d1be1ee65