### PR TITLE
Fix DST drift when expanding Outlook recurrences

### DIFF
--- a/src/Outlook/OutlookRecurrence.cs
+++ b/src/Outlook/OutlookRecurrence.cs
@@ -34,14 +34,20 @@ public partial class CalendarSyncService
 		}
 
 		var (baseStartLocal, baseStartUtc) = NormalizeOutlookTimes(appt.Start, appt.StartUTC, $"series '{appt.Subject}' start");
-		var (baseEndLocal, baseEndUtc) = NormalizeOutlookTimes(appt.End, appt.EndUTC, $"series '{appt.Subject}' end");
-		var seriesAllDay = DetermineAllDay(baseStartLocal, baseEndLocal, appt.AllDayEvent);
-		var baseDuration = baseEndUtc - baseStartUtc;
-		if (baseDuration <= TimeSpan.Zero)
-		{
-			_logger.LogWarning("Recurrence duration invalid for '{Subject}'. Falling back to 30 minutes.", appt.Subject);
-			baseDuration = TimeSpan.FromMinutes(30);
-		}
+                var (baseEndLocal, baseEndUtc) = NormalizeOutlookTimes(appt.End, appt.EndUTC, $"series '{appt.Subject}' end");
+                var seriesAllDay = DetermineAllDay(baseStartLocal, baseEndLocal, appt.AllDayEvent);
+                var baseDuration = baseEndUtc - baseStartUtc;
+                if (baseDuration <= TimeSpan.Zero)
+                {
+                        _logger.LogWarning("Recurrence duration invalid for '{Subject}'. Falling back to 30 minutes.", appt.Subject);
+                        baseDuration = TimeSpan.FromMinutes(30);
+                }
+
+                var baseLocalDuration = baseEndLocal - baseStartLocal;
+                if (baseLocalDuration <= TimeSpan.Zero)
+                {
+                        baseLocalDuration = baseDuration;
+                }
 
 		CalDateTime startCal;
 		CalDateTime endCal;
@@ -69,8 +75,8 @@ public partial class CalendarSyncService
 
 		var utcFrom = ConvertFromSourceLocalToUtc(from);
 		var utcTo = ConvertFromSourceLocalToUtc(to);
-		var occurrences = calEvent.GetOccurrences(utcFrom, utcTo);
-		AddCalculatedOccurrences(results, appt, occurrences, skipDates, baseDuration, seriesAllDay);
+                var occurrences = calEvent.GetOccurrences(utcFrom, utcTo);
+                AddCalculatedOccurrences(results, appt, occurrences, skipDates, baseDuration, baseLocalDuration, baseStartLocal, seriesAllDay);
 
 		return results;
 	}


### PR DESCRIPTION
## Summary
- ensure expanded recurrence instances keep the source timezone wall-clock time
- recompute UTC timestamps from corrected local values to avoid DST-related offsets

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe29cbde90832b8b1b0a2a522ef1df