### PR TITLE
Refine bin relocation and resolver

### DIFF
--- a/CalendarSync.csproj
+++ b/CalendarSync.csproj
@@ -58,4 +58,12 @@
     <Folder Include="build\" />
   </ItemGroup>
 
+  <Target Name="RelocateDlls" AfterTargets="Build">
+    <ItemGroup>
+      <RootDlls Include="$(OutputPath)*.dll" Exclude="$(OutputPath)bin\\**" />
+    </ItemGroup>
+    <MakeDir Directories="$(OutputPath)bin\" />
+    <Move SourceFiles="@(RootDlls)" DestinationFolder="$(OutputPath)bin\" Condition="@(RootDlls->Count()) != 0" />
+  </Target>
+
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -4,12 +4,26 @@ using Newtonsoft.Json;
 using Serilog;
 using Serilog.Events;
 using System.Diagnostics;
+using System.Reflection;
 using System.Windows.Forms;
 
 namespace CalendarSync;
 
 public class Program
 {
+	private static readonly Lazy<string> BinDirectory = new(() =>
+	{
+		var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin");
+		if (!Directory.Exists(path))
+			Directory.CreateDirectory(path);
+		return path;
+	});
+
+	static Program()
+	{
+		AppDomain.CurrentDomain.AssemblyResolve += ResolveFromBin;
+	}
+
 	[STAThread]
 	public static void Main(string[] args)
 	{
@@ -111,5 +125,14 @@ public class Program
 		}
 		catch { }
 		EventRecorder.WriteEntry(ex.ToString(), EventLogEntryType.Error);
+	}
+
+	private static Assembly? ResolveFromBin(object? _, ResolveEventArgs args)
+	{
+		var assemblyName = new AssemblyName(args.Name);
+		var candidatePath = Path.Combine(BinDirectory.Value, $"{assemblyName.Name}.dll");
+		if (File.Exists(candidatePath))
+			return Assembly.LoadFrom(candidatePath);
+		return null;
 	}
 }


### PR DESCRIPTION
## Summary
- streamline DLL relocation by batching moves and excluding existing bin contents
- simplify bin assembly resolution with a lazy bin path and a single static resolver hook

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not available in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490cf1e434832bb2bd246d72944e4a)