### PR TITLE
Relocate runtime dlls to bin

### DIFF
--- a/CalendarSync.csproj
+++ b/CalendarSync.csproj
@@ -58,4 +58,14 @@
     <Folder Include="build\" />
   </ItemGroup>
 
+  <Target Name="RelocateDlls" AfterTargets="Build">
+    <ItemGroup>
+      <RootDlls Include="$(OutputPath)*.dll" Exclude="$(OutputPath)bin\\**" />
+      <RuntimeDlls Include="$(OutputPath)runtimes\\win\\lib\\net8.0\\*.dll" />
+    </ItemGroup>
+    <MakeDir Directories="$(OutputPath)bin\" />
+    <Move SourceFiles="@(RootDlls)" DestinationFolder="$(OutputPath)bin\" Condition="@(RootDlls->Count()) != 0" />
+    <Move SourceFiles="@(RuntimeDlls)" DestinationFolder="$(OutputPath)bin\" Condition="@(RuntimeDlls->Count()) != 0" />
+  </Target>
+
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -4,12 +4,26 @@ using Newtonsoft.Json;
 using Serilog;
 using Serilog.Events;
 using System.Diagnostics;
+using System.Reflection;
 using System.Windows.Forms;
 
 namespace CalendarSync;
 
 public class Program
 {
+	private static readonly Lazy<string> BinDirectory = new(() =>
+	{
+		var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin");
+		if (!Directory.Exists(path))
+			Directory.CreateDirectory(path);
+		return path;
+	});
+
+	static Program()
+	{
+		AppDomain.CurrentDomain.AssemblyResolve += ResolveFromBin;
+	}
+
 	[STAThread]
 	public static void Main(string[] args)
 	{
@@ -111,5 +125,14 @@ public class Program
 		}
 		catch { }
 		EventRecorder.WriteEntry(ex.ToString(), EventLogEntryType.Error);
+	}
+
+	private static Assembly? ResolveFromBin(object? _, ResolveEventArgs args)
+	{
+		var assemblyName = new AssemblyName(args.Name);
+		var candidatePath = Path.Combine(BinDirectory.Value, $"{assemblyName.Name}.dll");
+		if (File.Exists(candidatePath))
+			return Assembly.LoadFrom(candidatePath);
+		return null;
 	}
 }


### PR DESCRIPTION
## Summary
- keep DLL outputs tidy by moving both root-level and runtimes/win/lib/net8.0 assemblies into the bin subfolder
- continue to load relocated dependencies via the static bin assembly resolver

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not available in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490cf1e434832bb2bd246d72944e4a)