### PR TITLE
Add build quickstart readme and clean output artifacts

### DIFF
--- a/CalendarSync.csproj
+++ b/CalendarSync.csproj
@@ -1,71 +1,82 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-      <OutputType>WinExe</OutputType>
-	  <ApplicationIcon>ico\cal64.ico</ApplicationIcon>
-    <TargetFramework>net8.0-windows</TargetFramework>
-	  <UseWindowsForms>true</UseWindowsForms>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <PlatformTarget>x86</PlatformTarget>
-      <OutputPath>Y:\calendar\</OutputPath>
-      <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-      <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <StartupObject>CalendarSync.Program</StartupObject>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<ApplicationIcon>ico\cal64.ico</ApplicationIcon>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<UseWindowsForms>true</UseWindowsForms>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<PlatformTarget>x86</PlatformTarget>
+		<OutputPath>Z:\Calendar\</OutputPath>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+		<StartupObject>CalendarSync.Program</StartupObject>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <COMReference Include="Microsoft.Office.Interop.Outlook">
-      <WrapperTool>tlbimp</WrapperTool>
-      <VersionMinor>6</VersionMinor>
-      <VersionMajor>9</VersionMajor>
-      <Guid>00062fff-0000-0000-c000-000000000046</Guid>
-      <Lcid>0</Lcid>
-      <Isolated>false</Isolated>
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Ical.Net" Version="5.0.0-pre.41" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Serilog" Version="4.2.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
+		<PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Ical.Net" Version="5.0.0-pre.41" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<COMReference Include="Microsoft.Office.Interop.Outlook">
+			<WrapperTool>tlbimp</WrapperTool>
+			<VersionMinor>6</VersionMinor>
+			<VersionMajor>9</VersionMajor>
+			<Guid>00062fff-0000-0000-c000-000000000046</Guid>
+			<Lcid>0</Lcid>
+			<Isolated>false</Isolated>
+			<EmbedInteropTypes>true</EmbedInteropTypes>
+		</COMReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="config.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </None>
-	<None Update="ico\cal64.ico">
-	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</None>
-	<None Update="ico\icon_delete.ico">
-	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</None>
-	<None Update="ico\icon_idle.ico">
-	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</None>
-	<None Update="ico\icon_update.ico">
-	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="build\Readme.txt">
+			<Link>Readme.txt</Link>
+			<CopyToOutputDirectory Condition="'$(Configuration)'=='Release'">PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="config.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="ico\cal64.ico">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="ico\icon_delete.ico">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="ico\icon_idle.ico">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="ico\icon_update.ico">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="build\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="build\" />
+	</ItemGroup>
 
-  <Target Name="RelocateDlls" AfterTargets="Build">
-    <ItemGroup>
-      <RootDlls Include="$(OutputPath)*.dll" Exclude="$(OutputPath)bin\\**" />
-      <RuntimeDlls Include="$(OutputPath)runtimes\\win\\lib\\net8.0\\*.dll" />
-    </ItemGroup>
-    <MakeDir Directories="$(OutputPath)bin\" />
-    <Move SourceFiles="@(RootDlls)" DestinationFolder="$(OutputPath)bin\" Condition="@(RootDlls->Count()) != 0" />
-    <Move SourceFiles="@(RuntimeDlls)" DestinationFolder="$(OutputPath)bin\" Condition="@(RuntimeDlls->Count()) != 0" />
-  </Target>
+	<Target Name="RelocateDlls" AfterTargets="Build">
+		<ItemGroup>
+			<RootDlls Include="$(OutputPath)*.dll" Exclude="$(OutputPath)bin\**" />
+			<RuntimeDlls Include="$(OutputPath)runtimes\win\lib\net8.0\*.dll" />
+		</ItemGroup>
+		<MakeDir Directories="$(OutputPath)bin\" />
+		<Move SourceFiles="@(RootDlls)" DestinationFolder="$(OutputPath)bin\" Condition="@(RootDlls->Count()) != 0" />
+		<Move SourceFiles="@(RuntimeDlls)" DestinationFolder="$(OutputPath)bin\" Condition="@(RuntimeDlls->Count()) != 0" />
+	</Target>
+
+	<Target Name="RemovePdbFiles" AfterTargets="RelocateDlls">
+		<ItemGroup>
+			<PdbFiles Include="$(OutputPath)**\*.pdb" />
+		</ItemGroup>
+		<Delete Files="@(PdbFiles)" TreatErrorsAsWarnings="false" />
+	</Target>
 
 </Project>

--- a/build/Readme.txt
+++ b/build/Readme.txt
@@ -1,0 +1,5 @@
+CalendarSync Build QuickStart
+1) Build in Release mode: dotnet build -c Release
+2) Copy CalendarSync.exe, config.json, and the bin subfolder from the build output into your install directory (e.g., C:\CalendarSync\).
+3) Edit config.json with your iCloud URL, Apple ID, app password, PrincipalId, and WorkCalendarId.
+4) Run CalendarSync.exe once to verify log output (sync.log) and then register it as a Scheduled Task (At log on → run with highest privileges).


### PR DESCRIPTION
## Summary
- add a concise build quickstart Readme to accompany generated output
- copy the sample config.json and Readme into the build root for easier deployment
- strip .pdb files from the build output after relocation to keep artifacts clean
- update build output path to Z:\\Calendar and simplify glob paths for relocation
- copy the packaged Readme only during Release builds for end-user distribution
- tidy the project file layout and group content metadata more cleanly

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694913449b08832b834b32e3bbc4de00)