### PR TITLE
Ensure native runtime DLLs are relocated into bin

### DIFF
--- a/CalendarSync.csproj
+++ b/CalendarSync.csproj
@@ -62,10 +62,11 @@
 	<Target Name="RelocateDlls" AfterTargets="Build">
 		<ItemGroup>
 			<RootDlls Include="$(OutputPath)*.dll"
-					  Exclude="
-						$(OutputPath)bin\**;
-						$(OutputPath)$(AssemblyName).dll" />
+				  Exclude="
+					$(OutputPath)bin\**;
+					$(OutputPath)$(AssemblyName).dll" />
 			<RuntimeDlls Include="$(OutputPath)runtimes\win\lib\net8.0\*.dll" />
+			<RuntimeNativeDlls Include="$(OutputPath)runtimes\win\native\**\*.dll" />
 			<RuntimeDirsToPrune Include="
 				$(OutputPath)runtimes\win\lib\net8.0;
 				$(OutputPath)runtimes\win\lib;
@@ -87,8 +88,14 @@
 			  Condition="@(RuntimeDlls->Count()) != 0" />
 		<Delete Files="@(RuntimeDlls)" Condition="@(RuntimeDlls->Count()) != 0" />
 
+		<Copy SourceFiles="@(RuntimeNativeDlls)"
+			  DestinationFolder="$(OutputPath)bin\"
+			  SkipUnchangedFiles="true"
+			  Condition="@(RuntimeNativeDlls->Count()) != 0" />
+		<Delete Files="@(RuntimeNativeDlls)" Condition="@(RuntimeNativeDlls->Count()) != 0" />
+
 		<RemoveDir Directories="@(RuntimeDirsToPrune)"
-				   Condition="Exists('%(RuntimeDirsToPrune.Identity)')" />
+			   Condition="Exists('%(RuntimeDirsToPrune.Identity)')" />
 	</Target>
 
 </Project>


### PR DESCRIPTION
## Summary
- include runtime native DLLs in the relocation target so they are copied into bin alongside managed assemblies
- clean up the relocation target to fully prune runtime folders after moving dependencies

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69492130cb6c832bb3182287aed2e005)