### PR TITLE
Add bootstrap diagnostics for startup failures

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -23,6 +23,7 @@ public class Program
 
 	static Program()
 	{
+		BootstrapDiagnostics.Initialize();
 		AppDomain.CurrentDomain.AssemblyResolve += ResolveFromBin;
 		AssemblyLoadContext.Default.Resolving += ResolveFromBin;
 		AssemblyLoadContext.Default.ResolvingUnmanagedDll += ResolveNativeFromBin;
@@ -31,10 +32,14 @@ public class Program
 	[STAThread]
 	public static void Main(string[] args)
 	{
+		BootstrapDiagnostics.Log("Main entry reached.");
 		EventRecorder.Initialize();
 		using var singleInstanceMutex = new System.Threading.Mutex(true, "CalendarSync", out var createdNewInstance);
 		if (!createdNewInstance)
+		{
+			BootstrapDiagnostics.Log("Another instance detected, exiting.");
 			return;
+		}
 		SubscribeToGlobalExceptions();
 		EventRecorder.WriteEntry("Application startup", EventLogEntryType.Information);
 
@@ -56,6 +61,7 @@ public class Program
 		};
 
 		host.StartAsync().GetAwaiter().GetResult();
+		BootstrapDiagnostics.Log("Host started, entering message loop.");
 		Application.Run();
 		EventRecorder.WriteEntry("Application shutdown", EventLogEntryType.Information);
 	}
@@ -67,6 +73,7 @@ public class Program
 						var configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
 						if (!File.Exists(configPath))
 						{
+							BootstrapDiagnostics.Log($"config.json missing at {configPath}.");
 							EventRecorder.WriteEntry("config.json not found", EventLogEntryType.Error);
 							throw new FileNotFoundException("config.json not found in the executable directory.");
 						}
@@ -105,6 +112,7 @@ public class Program
 								.CreateLogger();
 
 						services.AddLogging(builder => builder.AddSerilog(logger, dispose: true));
+						BootstrapDiagnostics.Log("Services configured successfully.");
 						EventRecorder.WriteEntry("Configuration loaded", EventLogEntryType.Information);
 					});
 
@@ -128,6 +136,7 @@ public class Program
 			Log.Fatal(ex, "Unhandled exception");
 		}
 		catch { }
+		BootstrapDiagnostics.Log($"Unhandled exception captured: {ex}");
 		EventRecorder.WriteEntry(ex.ToString(), EventLogEntryType.Error);
 	}
 
@@ -148,15 +157,25 @@ public class Program
 	{
 		var candidatePath = Path.Combine(BinDirectory.Value, $"{assemblyName.Name}.dll");
 		if (!File.Exists(candidatePath))
+		{
+			BootstrapDiagnostics.LogAssemblyProbe(assemblyName.Name ?? "unknown", candidatePath, false, false);
 			return null;
-		return AssemblyLoadContext.Default.LoadFromAssemblyPath(candidatePath);
+		}
+		var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(candidatePath);
+		BootstrapDiagnostics.LogAssemblyProbe(assemblyName.Name ?? "unknown", candidatePath, true, assembly != null);
+		return assembly;
 	}
 
 	private static IntPtr ResolveNativeFromBin(Assembly _, string name)
 	{
 		var candidatePath = Path.Combine(BinDirectory.Value, $"{name}.dll");
 		if (!File.Exists(candidatePath))
+		{
+			BootstrapDiagnostics.LogNativeProbe(name, candidatePath, false, false);
 			return IntPtr.Zero;
-		return NativeLibrary.Load(candidatePath);
+		}
+		var handle = NativeLibrary.Load(candidatePath);
+		BootstrapDiagnostics.LogNativeProbe(name, candidatePath, true, handle != IntPtr.Zero);
+		return handle;
 	}
 }

--- a/src/BootstrapDiagnostics.cs
+++ b/src/BootstrapDiagnostics.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+
+namespace CalendarSync;
+
+internal static class BootstrapDiagnostics
+{
+	private static readonly string LogPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bootstrap.log");
+	private static readonly object Sync = new();
+	private static bool _initialized;
+	private static int _firstChanceCount;
+	private const int MaxFirstChanceEntries = 5;
+
+	public static void Initialize()
+	{
+		if (_initialized)
+			return;
+		_initialized = true;
+		Log("Bootstrap diagnostics initialized.");
+		AppDomain.CurrentDomain.ProcessExit += (_, _) => Log("Process exit observed.");
+		AppDomain.CurrentDomain.FirstChanceException += (_, e) =>
+		{
+			var count = Interlocked.Increment(ref _firstChanceCount);
+			if (count <= MaxFirstChanceEntries)
+				Log($"First-chance exception: {e.Exception}");
+		};
+	}
+
+	public static void Log(string message)
+	{
+		try
+		{
+			var line = $"[{DateTime.UtcNow:u}] {message}{Environment.NewLine}";
+			lock (Sync)
+			{
+				File.AppendAllText(LogPath, line);
+			}
+		}
+		catch
+		{
+		}
+	}
+
+	public static void LogAssemblyProbe(string assemblyName, string candidatePath, bool exists, bool loaded)
+	{
+		Log($"Assembly probe for {assemblyName}: path={candidatePath}, exists={exists}, loaded={loaded}.");
+	}
+
+	public static void LogNativeProbe(string libraryName, string candidatePath, bool exists, bool loaded)
+	{
+		Log($"Native probe for {libraryName}: path={candidatePath}, exists={exists}, loaded={loaded}.");
+	}
+}


### PR DESCRIPTION
## Summary
- add bootstrap diagnostic helper that writes early startup events and first-chance exceptions to bootstrap.log
- log assembly and native DLL resolution attempts to surface missing or misplaced binaries
- capture key host configuration milestones in the bootstrap log for silent startup failures

## Testing
- dotnet build -p:EnableWindowsTargeting=true *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694924996ac0832bbf11e8b65eb49494)