### PR TITLE
Enhance bootstrap logging for startup crashes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -23,6 +23,7 @@ public class Program
 
 	static Program()
 	{
+		BootstrapDiagnostics.Initialize();
 		AppDomain.CurrentDomain.AssemblyResolve += ResolveFromBin;
 		AssemblyLoadContext.Default.Resolving += ResolveFromBin;
 		AssemblyLoadContext.Default.ResolvingUnmanagedDll += ResolveNativeFromBin;
@@ -31,33 +32,46 @@ public class Program
 	[STAThread]
 	public static void Main(string[] args)
 	{
-		EventRecorder.Initialize();
-		using var singleInstanceMutex = new System.Threading.Mutex(true, "CalendarSync", out var createdNewInstance);
-		if (!createdNewInstance)
-			return;
-		SubscribeToGlobalExceptions();
-		EventRecorder.WriteEntry("Application startup", EventLogEntryType.Information);
-
-		using var host = CreateHostBuilder(args).Build();
-		var tray = host.Services.GetRequiredService<TrayIconManager>();
-		var service = host.Services.GetRequiredService<CalendarSyncService>();
-
-		tray.ExitClicked += async (_, _) =>
+		try
 		{
-			EventRecorder.WriteEntry("Shutdown requested", EventLogEntryType.Information);
-			await host.StopAsync().ConfigureAwait(false);
-			tray.Dispose();
-			Application.Exit();
-		};
+			BootstrapDiagnostics.Log("Main entry reached.");
+			EventRecorder.Initialize();
+			using var singleInstanceMutex = new System.Threading.Mutex(true, "CalendarSync", out var createdNewInstance);
+			if (!createdNewInstance)
+			{
+				BootstrapDiagnostics.Log("Another instance detected, exiting.");
+				return;
+			}
+			SubscribeToGlobalExceptions();
+			EventRecorder.WriteEntry("Application startup", EventLogEntryType.Information);
 
-		tray.FullResyncClicked += async (_, _) =>
+			using var host = CreateHostBuilder(args).Build();
+			var tray = host.Services.GetRequiredService<TrayIconManager>();
+			var service = host.Services.GetRequiredService<CalendarSyncService>();
+
+			tray.ExitClicked += async (_, _) =>
+			{
+				EventRecorder.WriteEntry("Shutdown requested", EventLogEntryType.Information);
+				await host.StopAsync().ConfigureAwait(false);
+				tray.Dispose();
+				Application.Exit();
+			};
+
+			tray.FullResyncClicked += async (_, _) =>
+			{
+				await service.TriggerFullResyncAsync().ConfigureAwait(false);
+			};
+
+			host.StartAsync().GetAwaiter().GetResult();
+			BootstrapDiagnostics.Log("Host started, entering message loop.");
+			Application.Run();
+			EventRecorder.WriteEntry("Application shutdown", EventLogEntryType.Information);
+		}
+		catch (Exception ex)
 		{
-			await service.TriggerFullResyncAsync().ConfigureAwait(false);
-		};
-
-		host.StartAsync().GetAwaiter().GetResult();
-		Application.Run();
-		EventRecorder.WriteEntry("Application shutdown", EventLogEntryType.Information);
+			BootstrapDiagnostics.Log($"Fatal exception in Main: {ex}");
+			throw;
+		}
 	}
 
 	public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -67,6 +81,7 @@ public class Program
 						var configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
 						if (!File.Exists(configPath))
 						{
+							BootstrapDiagnostics.Log($"config.json missing at {configPath}.");
 							EventRecorder.WriteEntry("config.json not found", EventLogEntryType.Error);
 							throw new FileNotFoundException("config.json not found in the executable directory.");
 						}
@@ -105,6 +120,7 @@ public class Program
 								.CreateLogger();
 
 						services.AddLogging(builder => builder.AddSerilog(logger, dispose: true));
+						BootstrapDiagnostics.Log("Services configured successfully.");
 						EventRecorder.WriteEntry("Configuration loaded", EventLogEntryType.Information);
 					});
 
@@ -128,6 +144,7 @@ public class Program
 			Log.Fatal(ex, "Unhandled exception");
 		}
 		catch { }
+		BootstrapDiagnostics.Log($"Unhandled exception captured: {ex}");
 		EventRecorder.WriteEntry(ex.ToString(), EventLogEntryType.Error);
 	}
 
@@ -148,15 +165,25 @@ public class Program
 	{
 		var candidatePath = Path.Combine(BinDirectory.Value, $"{assemblyName.Name}.dll");
 		if (!File.Exists(candidatePath))
+		{
+			BootstrapDiagnostics.LogAssemblyProbe(assemblyName.Name ?? "unknown", candidatePath, false, false);
 			return null;
-		return AssemblyLoadContext.Default.LoadFromAssemblyPath(candidatePath);
+		}
+		var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(candidatePath);
+		BootstrapDiagnostics.LogAssemblyProbe(assemblyName.Name ?? "unknown", candidatePath, true, assembly != null);
+		return assembly;
 	}
 
 	private static IntPtr ResolveNativeFromBin(Assembly _, string name)
 	{
 		var candidatePath = Path.Combine(BinDirectory.Value, $"{name}.dll");
 		if (!File.Exists(candidatePath))
+		{
+			BootstrapDiagnostics.LogNativeProbe(name, candidatePath, false, false);
 			return IntPtr.Zero;
-		return NativeLibrary.Load(candidatePath);
+		}
+		var handle = NativeLibrary.Load(candidatePath);
+		BootstrapDiagnostics.LogNativeProbe(name, candidatePath, true, handle != IntPtr.Zero);
+		return handle;
 	}
 }

--- a/src/BootstrapDiagnostics.cs
+++ b/src/BootstrapDiagnostics.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+
+namespace CalendarSync;
+
+internal static class BootstrapDiagnostics
+{
+	private static readonly string LogPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bootstrap.log");
+	private static readonly object Sync = new();
+	private static bool _initialized;
+	private static int _firstChanceCount;
+	private const int MaxFirstChanceEntries = 5;
+	private const int MaxAssemblyLoadEntries = 10;
+	private static int _assemblyLoadCount;
+
+	public static void Initialize()
+	{
+		if (_initialized)
+			return;
+		_initialized = true;
+		Log($"Bootstrap diagnostics initialized. BaseDir={AppDomain.CurrentDomain.BaseDirectory}, WorkDir={Environment.CurrentDirectory}, Arch={RuntimeInformation.ProcessArchitecture}.");
+		LogDirectorySnapshot(AppDomain.CurrentDomain.BaseDirectory, 50);
+		AppDomain.CurrentDomain.ProcessExit += (_, _) => Log("Process exit observed.");
+		AppDomain.CurrentDomain.FirstChanceException += (_, e) =>
+		{
+			var count = Interlocked.Increment(ref _firstChanceCount);
+			if (count <= MaxFirstChanceEntries)
+				Log($"First-chance exception: {e.Exception}");
+		};
+		AppDomain.CurrentDomain.AssemblyLoad += (_, e) =>
+		{
+			var count = Interlocked.Increment(ref _assemblyLoadCount);
+			if (count <= MaxAssemblyLoadEntries)
+				Log($"Assembly loaded: {e.LoadedAssembly.FullName} ({e.LoadedAssembly.Location})");
+		};
+	}
+
+	public static void Log(string message)
+	{
+		try
+		{
+			var line = $"[{DateTime.UtcNow:u}] {message}{Environment.NewLine}";
+			lock (Sync)
+			{
+				File.AppendAllText(LogPath, line);
+			}
+		}
+		catch
+		{
+		}
+	}
+
+	public static void LogAssemblyProbe(string assemblyName, string candidatePath, bool exists, bool loaded)
+	{
+		Log($"Assembly probe for {assemblyName}: path={candidatePath}, exists={exists}, loaded={loaded}.");
+	}
+
+	public static void LogNativeProbe(string libraryName, string candidatePath, bool exists, bool loaded)
+	{
+		Log($"Native probe for {libraryName}: path={candidatePath}, exists={exists}, loaded={loaded}.");
+	}
+
+	private static void LogDirectorySnapshot(string directory, int maxEntries)
+	{
+		try
+		{
+			if (!Directory.Exists(directory))
+			{
+				Log($"Directory snapshot skipped; missing directory {directory}.");
+				return;
+			}
+			var entries = Directory.EnumerateFileSystemEntries(directory, "*", SearchOption.TopDirectoryOnly)
+					.Take(maxEntries)
+					.ToArray();
+			Log($"Directory snapshot for {directory} ({entries.Length} entries, max {maxEntries}):");
+			foreach (var entry in entries)
+				Log($" - {entry}");
+		}
+		catch
+		{
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- wrap Main in fatal logging to ensure any crash is recorded to bootstrap.log
- log process baseline info, directory contents, and early assembly loads to surface missing DLLs
- keep probe logging for managed/native resolution to capture relocation issues

## Testing
- dotnet build -p:EnableWindowsTargeting=true *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694924996ac0832bbf11e8b65eb49494)