### PR TITLE
Keep Microsoft.Extensions assemblies in the root output directory

### DIFF
--- a/CalendarSync.csproj
+++ b/CalendarSync.csproj
@@ -61,10 +61,12 @@
 
 	<Target Name="RelocateDlls" AfterTargets="Build">
 		<ItemGroup>
+			<DllsToKeepInRoot Include="$(OutputPath)Microsoft.Extensions.*.dll" />
 			<RootDlls Include="$(OutputPath)*.dll"
 				  Exclude="
 					$(OutputPath)bin\**;
-					$(OutputPath)$(AssemblyName).dll" />
+					$(OutputPath)$(AssemblyName).dll;
+					@(DllsToKeepInRoot)" />
 			<RuntimeDlls Include="$(OutputPath)runtimes\win\lib\net8.0\*.dll" />
 			<RuntimeNativeDlls Include="$(OutputPath)runtimes\win\native\**\*.dll" />
 			<RuntimeDirsToPrune Include="


### PR DESCRIPTION
## Summary
- keep Microsoft.Extensions assemblies in the root output to avoid early startup resolution failures
- continue relocating the remaining assemblies to the bin folder while pruning runtime subdirectories

## Testing
- dotnet build -p:OutputPath=./artifacts/ *(fails: missing Microsoft.NET.Sdk.WindowsDesktop in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69492e517590832b96bde11f4facbcf0)