### PR TITLE
Two-file log rotation; fix Outlook COM import and STA task completion safety

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -106,17 +106,11 @@ public class Program
 							serilogLevel = parsedLevel;
 						}
 						var logFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "sync.log");
+						var oldLogFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "sync.log.old");
 
 						var logger = new LoggerConfiguration()
 								.MinimumLevel.Is(serilogLevel)
-									.WriteTo.File(
-									logFilePath,
-									rollOnFileSizeLimit: true,
-									fileSizeLimitBytes: 1_048_576,
-									rollingInterval: RollingInterval.Infinite,
-									retainedFileCountLimit: 1,
-									shared: true
-									)
+								.WriteTo.Sink(new TwoFileRollingSink(logFilePath, oldLogFilePath, 1_048_576))
 								.CreateLogger();
 
 						services.AddLogging(builder => builder.AddSerilog(logger, dispose: true));

--- a/src/CalendarSyncService.cs
+++ b/src/CalendarSyncService.cs
@@ -40,8 +40,8 @@ public partial class CalendarSyncService : BackgroundService
 	private CancellationToken _serviceStoppingToken = CancellationToken.None;
 	private static readonly Guid OutlookApplicationClsid = new("0006F03A-0000-0000-C000-000000000046");
 
-	[DllImport("oleaut32.dll")]
-	private static extern int GetActiveObjectNative(ref Guid rclsid, IntPtr pvReserved, [MarshalAs(UnmanagedType.IUnknown)] out object? ppunk);
+	[DllImport("oleaut32.dll", EntryPoint = "GetActiveObject")]
+	private static extern int GetActiveObject(ref Guid rclsid, IntPtr pvReserved, [MarshalAs(UnmanagedType.IUnknown)] out object? ppunk);
 
 	public CalendarSyncService(SyncConfig config, ILogger<CalendarSyncService> logger, TrayIconManager tray)
 	{

--- a/src/Logging/TwoFileRollingSink.cs
+++ b/src/Logging/TwoFileRollingSink.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using System.Text;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Display;
+
+namespace CalendarSync;
+
+public sealed class TwoFileRollingSink : ILogEventSink, IDisposable
+{
+	private static readonly Encoding LogEncoding = new UTF8Encoding(false);
+	private readonly string _logPath;
+	private readonly string _oldLogPath;
+	private readonly long _fileSizeLimitBytes;
+	private readonly ITextFormatter _formatter;
+	private readonly object _syncRoot = new();
+	private StreamWriter? _writer;
+	private long _currentSize;
+
+	public TwoFileRollingSink(string logPath, string oldLogPath, long fileSizeLimitBytes)
+	{
+		_logPath = logPath ?? throw new ArgumentNullException(nameof(logPath));
+		_oldLogPath = oldLogPath ?? throw new ArgumentNullException(nameof(oldLogPath));
+		if (fileSizeLimitBytes <= 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(fileSizeLimitBytes));
+		}
+		_fileSizeLimitBytes = fileSizeLimitBytes;
+		_formatter = new MessageTemplateTextFormatter(
+			"{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}",
+			CultureInfo.InvariantCulture);
+	}
+
+	public void Emit(LogEvent logEvent)
+	{
+		if (logEvent == null)
+		{
+			return;
+		}
+
+		string formatted;
+		using (var writer = new StringWriter(CultureInfo.InvariantCulture))
+		{
+			_formatter.Format(logEvent, writer);
+			formatted = writer.ToString();
+		}
+
+		var bytesToWrite = LogEncoding.GetByteCount(formatted);
+
+		lock (_syncRoot)
+		{
+			EnsureWriter();
+			if (_currentSize + bytesToWrite > _fileSizeLimitBytes)
+			{
+				Roll();
+			}
+
+			_writer!.Write(formatted);
+			_currentSize += bytesToWrite;
+		}
+	}
+
+	public void Dispose()
+	{
+		lock (_syncRoot)
+		{
+			if (_writer != null)
+			{
+				_writer.Flush();
+				_writer.Dispose();
+				_writer = null;
+			}
+		}
+	}
+
+	private void EnsureWriter()
+	{
+		if (_writer != null)
+		{
+			return;
+		}
+
+		var directory = Path.GetDirectoryName(_logPath);
+		if (!string.IsNullOrWhiteSpace(directory))
+		{
+			Directory.CreateDirectory(directory);
+		}
+
+		var stream = new FileStream(_logPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+		_writer = new StreamWriter(stream, LogEncoding) { AutoFlush = true };
+		_currentSize = stream.Length;
+	}
+
+	private void Roll()
+	{
+		_writer?.Flush();
+		_writer?.Dispose();
+		_writer = null;
+
+		if (File.Exists(_logPath))
+		{
+			File.Move(_logPath, _oldLogPath, true);
+		}
+
+		EnsureWriter();
+	}
+}

--- a/src/Outlook/OutlookInterop.cs
+++ b/src/Outlook/OutlookInterop.cs
@@ -59,7 +59,7 @@ public partial class CalendarSyncService
 		try
 		{
 			var clsid = OutlookApplicationClsid;
-			var hr = GetActiveObjectNative(ref clsid, IntPtr.Zero, out var activeObject);
+			var hr = GetActiveObject(ref clsid, IntPtr.Zero, out var activeObject);
 			if (hr < 0)
 			{
 				Marshal.ThrowExceptionForHR(hr);

--- a/src/StaTask.cs
+++ b/src/StaTask.cs
@@ -14,19 +14,19 @@ public static class StaTask
 			try
 			{
 				action();
-				tcs.SetResult();
+				tcs.TrySetResult();
 			}
 			catch (OperationCanceledException oce)
 			{
-				tcs.SetCanceled(oce.CancellationToken);
+				tcs.TrySetCanceled(oce.CancellationToken);
 			}
 			catch (ThreadInterruptedException)
 			{
-				tcs.SetCanceled(token);
+				tcs.TrySetCanceled(token);
 			}
 			catch (Exception ex)
 			{
-				tcs.SetException(ex);
+				tcs.TrySetException(ex);
 			}
 		});
 		thread.SetApartmentState(ApartmentState.STA);
@@ -57,19 +57,19 @@ public static class StaTask
 			try
 			{
 				var result = func();
-				tcs.SetResult(result);
+				tcs.TrySetResult(result);
 			}
 			catch (OperationCanceledException oce)
 			{
-				tcs.SetCanceled(oce.CancellationToken);
+				tcs.TrySetCanceled(oce.CancellationToken);
 			}
 			catch (ThreadInterruptedException)
 			{
-				tcs.SetCanceled(token);
+				tcs.TrySetCanceled(token);
 			}
 			catch (Exception ex)
 			{
-				tcs.SetException(ex);
+				tcs.TrySetException(ex);
 			}
 		});
 		thread.SetApartmentState(ApartmentState.STA);


### PR DESCRIPTION
### Motivation
- Ensure logging rotates using a `sync.log` / `sync.log.old` tandem and overwrites the `.old` file when the current file exceeds the size limit.
- Prevent the service from crashing at startup by binding to the correct native COM entry for retrieving the running Outlook instance.
- Avoid `InvalidOperationException` from double-setting `TaskCompletionSource` on STA helper threads by making completions idempotent.

### Description
- Replace the Serilog rolling-file configuration in `Program.cs` with a custom `TwoFileRollingSink` that rolls `sync.log` to `sync.log.old` when the file exceeds `1_048_576` bytes and continues on a fresh `sync.log`.
- Add `src/Logging/TwoFileRollingSink.cs` implementing `ILogEventSink` which enforces the two-file size-based rotation and overwrites the `.old` file when rolling.
- Change the Outlook COM import to `[DllImport("oleaut32.dll", EntryPoint = "GetActiveObject")]` and call `GetActiveObject` in `TryGetRunningOutlookInstance` to fix the native binding.
- Update `StaTask.cs` to use `TrySetResult`, `TrySetCanceled`, and `TrySetException` so `TaskCompletionSource` transitions are safe and idempotent.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965f254de50832bbfcf3e28a6e2939f)