### PR TITLE
Handle startup failures gracefully to mitigate Windows system error dialog

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -32,6 +32,7 @@ public class Program
 	[STAThread]
 	public static void Main(string[] args)
 	{
+		Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
 		try
 		{
 			BootstrapDiagnostics.Log("Main entry reached.");
@@ -70,7 +71,20 @@ public class Program
 		catch (Exception ex)
 		{
 			BootstrapDiagnostics.Log($"Fatal exception in Main: {ex}");
-			throw;
+			EventRecorder.WriteEntry($"Fatal startup error: {ex}", EventLogEntryType.Error);
+			try
+			{
+				MessageBox.Show(
+					"CalendarSync failed to start. Check bootstrap.log and sync.log in the application directory for details.",
+					"CalendarSync Startup Error",
+					MessageBoxButtons.OK,
+					MessageBoxIcon.Error);
+			}
+			catch
+			{
+			}
+
+			Environment.ExitCode = 1;
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent abrupt Windows crash dialogs on startup by routing WinForms UI exceptions through managed handlers and providing actionable diagnostics.
- Give users a clear, non-technical error message and ensure the process exits with a non-zero code for automation scenarios.

### Description
- Call `Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException)` at program entry to route UI-thread exceptions to managed handlers.
- Replace the previous rethrow in `Program.Main` fatal `catch` with logging to `bootstrap.log`, an `EventRecorder` entry, a friendly `MessageBox` error, and set `Environment.ExitCode = 1` to indicate failure.
- Keep all original startup flow and diagnostics in place while avoiding an unhandled crash dialog on Windows.

### Testing
- Attempted `dotnet build -c Release` in the container, which failed because `Microsoft.NET.Sdk.WindowsDesktop` is unavailable in the Linux environment (build not reproducible here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de25b0bdc8832bb388d0743275533d)