### PR TITLE
Fix GetOccurrences call and guard iCloud serialized content

### DIFF
--- a/src/ICloud/ICloudSync.cs
+++ b/src/ICloud/ICloudSync.cs
@@ -81,7 +81,7 @@ public partial class CalendarSyncService
 			var calEvent = CreateCalendarEvent(dto, uid);
 			var calendar = new Calendar { Events = { calEvent } };
 			var serializer = new CalendarSerializer();
-			var newIcs = serializer.SerializeToString(calendar);
+			var newIcs = serializer.SerializeToString(calendar) ?? string.Empty;
 
 			var eventUrl = $"{calendarUrl}{uid}.ics";
 

--- a/src/Outlook/OutlookRecurrence.cs
+++ b/src/Outlook/OutlookRecurrence.cs
@@ -34,20 +34,20 @@ public partial class CalendarSyncService
 		}
 
 		var (baseStartLocal, baseStartUtc) = NormalizeOutlookTimes(appt.Start, appt.StartUTC, $"series '{appt.Subject}' start");
-                var (baseEndLocal, baseEndUtc) = NormalizeOutlookTimes(appt.End, appt.EndUTC, $"series '{appt.Subject}' end");
-                var seriesAllDay = DetermineAllDay(baseStartLocal, baseEndLocal, appt.AllDayEvent);
-                var baseDuration = baseEndUtc - baseStartUtc;
-                if (baseDuration <= TimeSpan.Zero)
-                {
-                        _logger.LogWarning("Recurrence duration invalid for '{Subject}'. Falling back to 30 minutes.", appt.Subject);
-                        baseDuration = TimeSpan.FromMinutes(30);
-                }
+		var (baseEndLocal, baseEndUtc) = NormalizeOutlookTimes(appt.End, appt.EndUTC, $"series '{appt.Subject}' end");
+		var seriesAllDay = DetermineAllDay(baseStartLocal, baseEndLocal, appt.AllDayEvent);
+		var baseDuration = baseEndUtc - baseStartUtc;
+		if (baseDuration <= TimeSpan.Zero)
+		{
+			_logger.LogWarning("Recurrence duration invalid for '{Subject}'. Falling back to 30 minutes.", appt.Subject);
+			baseDuration = TimeSpan.FromMinutes(30);
+		}
 
-                var baseLocalDuration = baseEndLocal - baseStartLocal;
-                if (baseLocalDuration <= TimeSpan.Zero)
-                {
-                        baseLocalDuration = baseDuration;
-                }
+		var baseLocalDuration = baseEndLocal - baseStartLocal;
+		if (baseLocalDuration <= TimeSpan.Zero)
+		{
+			baseLocalDuration = baseDuration;
+		}
 
 		CalDateTime startCal;
 		CalDateTime endCal;
@@ -75,8 +75,10 @@ public partial class CalendarSyncService
 
 		var utcFrom = ConvertFromSourceLocalToUtc(from);
 		var utcTo = ConvertFromSourceLocalToUtc(to);
-                var occurrences = calEvent.GetOccurrences(utcFrom, utcTo);
-                AddCalculatedOccurrences(results, appt, occurrences, skipDates, baseDuration, baseLocalDuration, baseStartLocal, seriesAllDay);
+		var fromCal = new CalDateTime(utcFrom, CalDateTime.UtcTzId);
+		var toCal = new CalDateTime(utcTo, CalDateTime.UtcTzId);
+		var occurrences = calEvent.GetOccurrences(fromCal, toCal);
+		AddCalculatedOccurrences(results, appt, occurrences, skipDates, baseDuration, baseLocalDuration, baseStartLocal, seriesAllDay);
 
 		return results;
 	}


### PR DESCRIPTION
### Motivation
- Resolve a type-mismatch and nullability issue that prevented correct recurrence expansion and produced a nullable `StringContent` argument when syncing to iCloud.

### Description
- Convert the UTC window to `CalDateTime` and call `calEvent.GetOccurrences(fromCal, toCal)` in `src/Outlook/OutlookRecurrence.cs` to match `Ical.Net` API expectations.
- Normalize indentation in the modified recurrence block for consistent formatting in `src/Outlook/OutlookRecurrence.cs`.
- Guard the iCloud ICS payload by using `serializer.SerializeToString(calendar) ?? string.Empty` before creating `StringContent` in `src/ICloud/ICloudSync.cs` to avoid nullable warnings.

### Testing
- Ran `dotnet build -nologo` in the container; the build was blocked by missing `Microsoft.NET.Sdk.WindowsDesktop` targets in the environment so full compilation could not be validated here.
- Changes are small, compile-focused fixes; please run a full build on a Windows machine with the .NET Desktop workload to confirm success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1064750014832bb870a12bc2284762)