### PR TITLE
Align repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,39 +1,30 @@
 # Repository agent instructions
 
-## Implementation language
+## Working standard
 
-- Prefer Rust over Python for new or substantially reworked long-running,
-  privileged, concurrent, network-facing, performance-sensitive, or
-  system-level components when Rust's ecosystem fits the task. Favor small,
-  typed modules, bounded inputs, explicit error handling, and minimal,
-  documented unsafe code.
-- Keep Python or the established language when it is materially safer or
-  simpler for scripts, orchestration, data work, ecosystem-specific
-  integrations, or small operator glue. Do not rewrite working components
-  solely to change languages; preserve stable CLI, schema, deployment, and
-  rollback contracts.
+- Write English documentation and agent text in ASD-STE100-oriented technical
+  English. Use active voice, short sentences, one instruction per step, and
+  consistent terms. Keep exact source text unchanged.
+- Use trunk-based development. `main` is the only long-lived branch. Start
+  from updated `main`. Keep feature branches small and short-lived.
+- Merge validated branches into `main` as soon as authority permits. Delete
+  merged branches, prune refs, and never force-push `main`.
+- If work cannot merge, record its branch, commit, checks, remaining work, and
+  owner. This policy does not authorize Git or live mutations.
+- Prefer Rust over Python for new components and substantial rework when Rust
+  is practical. Prioritize it for long-running, privileged, concurrent,
+  network-facing, performance-sensitive, or system-level code.
+- Keep the established language when it is safer or its ecosystem requires it.
+  Do not rewrite only to change language. Preserve interfaces, schemas,
+  deployment, rollback, and resource limits.
 
-## Credential safety
+## Credential and LAN safety
 
-- Never create, change, rotate, reset, revoke, or delete any credential or
-  authentication setting unless Philipp explicitly instructs that exact
-  change.
-- Suspected or actual exposure does not grant permission to rotate a
-  credential. Stop, report the issue, and ask for explicit authorization.
-- Do not infer credential-change authorization from a broader debugging,
-  deployment, security, recovery, or repair request.
-
-## LAN and Vaultwarden secret discovery
-
-- For an explicitly authorized LAN login or privileged operation, start with
-  `D:\AGENTS.md`. The ACL-restricted `D:\.env` is only the Windows Vaultwarden
-  bootstrap; it is not a repository env file and does not hold the target
-  machine's operational secret.
-- Never open, print, source, copy, or commit `D:\.env` directly. Use
-  `D:\Vaultwarden\scripts\vaultwarden-local.ps1` as documented by the root
-  guide to locate the appropriate shared `Elhaus` collection and materialize
-  only the exact authorized file-backed item to a new ACL-restricted temporary
-  path outside the repository. Remove that file immediately after use.
-- LAN logins, sudo credentials, SSH/private keys, certificates, and recovery
-  material belong in the relevant host/service collection. Do not guess item
-  names, recreate `.local-secrets/`, or rotate credentials by inference.
+- Change credentials only with Philipp's exact authorization. Exposure and
+  broader tasks do not give this authority. Report exposure without its value.
+- Keep secrets, keys, certificates, customer data, and runtime exports out of
+  Git, output, logs, documentation, fixtures, and process arguments.
+- For authorized LAN work, follow `D:\AGENTS.md`. Never open or expose
+  `D:\.env`. Materialize one exact item to a new ACL-restricted temporary
+  path. Remove it immediately.
+- Do not guess item names or recreate `.local-secrets/`.


### PR DESCRIPTION
Align the repository agent guide with the workspace trunk, language, safety, and handoff standards. Documentation-only validation: git diff --check passed.